### PR TITLE
Hide delete-account link for unauthenticated users on legal pages

### DIFF
--- a/src/app/legal/privacy/privacy.component.html
+++ b/src/app/legal/privacy/privacy.component.html
@@ -137,7 +137,7 @@
           <div class="col-md-6">
             <div class="card h-100">
               <div class="card-body py-2">
-                <p class="small mb-0"><strong>Erasure (<a href="https://gdpr-info.eu/art-17-gdpr/" target="_blank" rel="noopener">Art. 17</a>)</strong> &mdash; Request deletion of your data. You can <a routerLink="/settings/delete-user">delete your account</a> directly.</p>
+                <p class="small mb-0"><strong>Erasure (<a href="https://gdpr-info.eu/art-17-gdpr/" target="_blank" rel="noopener">Art. 17</a>)</strong> &mdash; Request deletion of your data. You can @if (auth.isAuthenticated()) {<a routerLink="/settings/delete-user">delete your account</a>} @else {delete your account} directly.</p>
               </div>
             </div>
           </div>

--- a/src/app/legal/privacy/privacy.component.ts
+++ b/src/app/legal/privacy/privacy.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { AuthService } from '../../shared/service/auth.service';
 
 @Component({
   selector: 'app-privacy',
@@ -8,5 +9,5 @@ import { RouterLink } from '@angular/router';
   styleUrl: './privacy.component.css'
 })
 export class PrivacyComponent {
-
+  readonly auth = inject(AuthService);
 }

--- a/src/app/legal/terms/terms.component.html
+++ b/src/app/legal/terms/terms.component.html
@@ -67,7 +67,7 @@
 
       <section class="mb-4">
         <h2 class="h5 fw-semibold">10. Termination</h2>
-        <p>We reserve the right to suspend or terminate your account if you violate these terms. You may <a routerLink="/settings/delete-user">delete your account</a> at any time. Upon deletion, your data will be removed in accordance with our <a routerLink="/privacy">Privacy Policy</a>.</p>
+        <p>We reserve the right to suspend or terminate your account if you violate these terms. You may @if (auth.isAuthenticated()) {<a routerLink="/settings/delete-user">delete your account</a>} @else {delete your account} at any time. Upon deletion, your data will be removed in accordance with our <a routerLink="/privacy">Privacy Policy</a>.</p>
       </section>
 
       <section class="mb-4">

--- a/src/app/legal/terms/terms.component.ts
+++ b/src/app/legal/terms/terms.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { AuthService } from '../../shared/service/auth.service';
 
 @Component({
   selector: 'app-terms',
@@ -8,5 +9,5 @@ import { RouterLink } from '@angular/router';
   styleUrl: './terms.component.css'
 })
 export class TermsComponent {
-
+  readonly auth = inject(AuthService);
 }

--- a/src/app/shared/service/auth.service.ts
+++ b/src/app/shared/service/auth.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, signal, effect, inject } from '@angular/core';
+import {
+  KEYCLOAK_EVENT_SIGNAL,
+  KeycloakEventType,
+  typeEventArgs,
+  ReadyArgs
+} from 'keycloak-angular';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  readonly isAuthenticated = signal(false);
+
+  private readonly keycloakSignal = inject(KEYCLOAK_EVENT_SIGNAL);
+
+  constructor() {
+    effect(() => {
+      const event = this.keycloakSignal();
+      if (event.type === KeycloakEventType.Ready) {
+        this.isAuthenticated.set(typeEventArgs<ReadyArgs>(event.args));
+      }
+      if (event.type === KeycloakEventType.AuthLogout) {
+        this.isAuthenticated.set(false);
+      }
+    });
+  }
+}


### PR DESCRIPTION
Extracted shared AuthService to avoid duplicating the Keycloak event pattern. Terms and Privacy pages now show the delete-account route as a plain text (no link) when the user is not logged in.