### PR TITLE
Add i18n with Transloco — EN, IT, DE, ES (#105)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/material": "~20.1.5",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
+        "@jsverse/transloco": "^8.3.0",
         "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",
         "keycloak-angular": "^20.0.0",
@@ -1088,7 +1089,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -1293,7 +1293,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3456,6 +3455,40 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@jsverse/transloco": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@jsverse/transloco/-/transloco-8.3.0.tgz",
+      "integrity": "sha512-p69/MhhAsTabDAffaiMALx4u9AwAqx24CjdECaCkUKSpCGbiYQUJPCsV4OsWjaSOxDNm9HuIX6NmqbfNZ0S3KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsverse/transloco-utils": "^8.2.1",
+        "@jsverse/utils": "1.0.0-beta.5",
+        "tslib": "^2.2.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=16.0.0",
+        "rxjs": ">=6.0.0"
+      }
+    },
+    "node_modules/@jsverse/transloco-utils": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@jsverse/transloco-utils/-/transloco-utils-8.3.0.tgz",
+      "integrity": "sha512-HZPDKadKiL3l4iZ51PF7gv7txBgrR7gQB6crdfLSrXsCvCTGDnnhd3y5qO02pBWbWMDKRXKU0clv2dd3jeTSFA==",
+      "license": "MIT",
+      "dependencies": {
+        "cosmiconfig": "^8.1.3",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jsverse/utils": {
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@jsverse/utils/-/utils-1.0.0-beta.5.tgz",
+      "integrity": "sha512-z7IdlV6BdSeF3Veii8Yyk64KuyTjNIQnFaW5PAhmDx0wN29lB2BFp8WO6+tJPLPjtlz2yKeNrjkp1XqnMPaeHA==",
+      "license": "MIT"
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
       "version": "3.3.0",
@@ -6444,7 +6477,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6868,6 +6900,50 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -7325,7 +7401,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -8580,6 +8655,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -8663,7 +8763,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-binary-path": {
@@ -10307,7 +10406,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -10819,7 +10917,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/listr2": {
@@ -12067,11 +12164,22 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -12090,7 +12198,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/parse5": {
@@ -12242,11 +12349,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -13829,7 +13944,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@angular/material": "~20.1.5",
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
+    "@jsverse/transloco": "^8.3.0",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
     "keycloak-angular": "^20.0.0",
@@ -39,9 +40,9 @@
   },
   "devDependencies": {
     "@angular/build": "^20.0.5",
-    "@angular/platform-browser-dynamic": "20.0.6",
     "@angular/cli": "^20.0.5",
     "@angular/compiler-cli": "^20.0.0",
+    "@angular/platform-browser-dynamic": "20.0.6",
     "@types/jasmine": "~5.1.0",
     "@types/jest": "^30.0.0",
     "jasmine-core": "~5.7.0",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -1,0 +1,98 @@
+{
+  "header": {
+    "home": "Startseite",
+    "words": "Wörter",
+    "myWords": "Meine Wörter",
+    "addWord": "Wort hinzufügen",
+    "flashcards": "Lernkarten",
+    "settings": "Einstellungen",
+    "myLanguages": "Meine Sprachen",
+    "roles": "Rollen",
+    "deleteAccount": "Konto löschen",
+    "login": "Anmelden",
+    "register": "Registrieren",
+    "logout": "Abmelden"
+  },
+  "landing": {
+    "hero": {
+      "title": "Vocabulary Builder",
+      "subtitle": "Das Beste aus traditionellen Vokabelheften — jetzt digital.",
+      "description": "Organisiere, lerne und festige neue Wörter mit der Kraft interaktiver Lernkarten.",
+      "myWords": "Meine Wörter",
+      "flashcards": "Lernkarten",
+      "getStarted": "Jetzt starten",
+      "tryDemo": "Demo ausprobieren",
+      "haveAccount": "Hast du bereits ein Konto oder ein Google-Konto?",
+      "logIn": "Anmelden",
+      "forgotPassword": "Passwort vergessen?"
+    },
+    "features": {
+      "title": "So funktioniert es",
+      "subtitle": "Drei einfache Schritte zum Aufbau deines Wortschatzes",
+      "organize": {
+        "title": "Organisieren",
+        "description": "Halte Wörter ordentlich wie in einem Heft — nur smarter, durchsuchbar und immer dabei."
+      },
+      "learn": {
+        "title": "Lernen",
+        "description": "Nutze Lernkarten und Spaced Repetition, um neue Wörter langfristig zu behalten.",
+        "practiceNow": "Jetzt üben →",
+        "tryDemo": "Demo ausprobieren →"
+      },
+      "grow": {
+        "title": "Wachsen",
+        "description": "Verfolge deinen Fortschritt in mehreren Sprachen und feiere deine Meilensteine."
+      }
+    },
+    "cta": {
+      "title": "Bereit, deinen Wortschatz zu erweitern?",
+      "subtitle": "Kostenlos registrieren und noch heute loslegen.",
+      "createAccount": "Konto erstellen"
+    }
+  },
+  "demo": {
+    "title": "Lernkarten-Demo ausprobieren",
+    "subtitle": "Wähle ein Sprachpaar und übe 8 häufige Wörter — kein Konto erforderlich.",
+    "from": "Von",
+    "to": "Nach",
+    "startPractice": "Übung starten",
+    "wantOwnWords": "Möchtest du mit deinen eigenen Wörtern üben?",
+    "createFreeAccount": "Kostenloses Konto erstellen",
+    "change": "Ändern",
+    "cardProgress": "Karte {{ current }} von {{ total }}",
+    "tapHint": "Karte antippen, um die Übersetzung anzuzeigen",
+    "skip": "Überspringen",
+    "right": "Richtig",
+    "wrong": "Falsch",
+    "skipped": "Übersprungen",
+    "sessionComplete": "Sitzung abgeschlossen!",
+    "reviewed": "Du hast {{ total }} Wörter wiederholt:",
+    "practiceAgain": "Nochmal üben",
+    "changeLanguages": "Sprachen wechseln",
+    "ctaTitle": "Mit deinem eigenen Wortschatz üben",
+    "ctaSubtitle": "Erstelle ein kostenloses Konto, um eigene Wörter hinzuzufügen und deinen Fortschritt zu verfolgen.",
+    "createFreeAccountBtn": "Kostenloses Konto erstellen",
+    "alreadyHaveAccount": "Hast du bereits ein Konto?",
+    "logIn": "Anmelden"
+  },
+  "register": {
+    "title": "Bei Vocabulary registrieren",
+    "subtitle": "Erstelle dein Konto und leg los",
+    "username": "Benutzername",
+    "usernamePlaceholder": "Wähle einen Benutzernamen",
+    "usernameInvalid": "Bitte gib einen gültigen Benutzernamen ein",
+    "firstName": "Vorname",
+    "firstNameInvalid": "Bitte gib einen gültigen Vornamen ein",
+    "lastName": "Nachname",
+    "lastNameInvalid": "Bitte gib einen gültigen Nachnamen ein",
+    "email": "E-Mail",
+    "emailPlaceholder": "du@beispiel.de",
+    "emailInvalid": "Bitte gib eine gültige E-Mail-Adresse ein",
+    "creating": "Konto wird erstellt...",
+    "submit": "Registrieren",
+    "orSkip": "Oder direkt einloggen ohne Registrierung",
+    "loginGoogle": "Mit Google anmelden",
+    "successMessage": "✅ Überprüfe deine E-Mail, um die Registrierung abzuschließen.",
+    "errorMessage": "❌ Etwas ist schiefgelaufen."
+  }
+}

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,0 +1,98 @@
+{
+  "header": {
+    "home": "Home",
+    "words": "Words",
+    "myWords": "My Words",
+    "addWord": "Add Word",
+    "flashcards": "Flashcards",
+    "settings": "Settings",
+    "myLanguages": "My Languages",
+    "roles": "Roles",
+    "deleteAccount": "Delete Account",
+    "login": "Login",
+    "register": "Register",
+    "logout": "Logout"
+  },
+  "landing": {
+    "hero": {
+      "title": "Vocabulary Builder",
+      "subtitle": "Embrace the essence of traditional paper vocabularies in a digital format.",
+      "description": "Effortlessly organize, learn, and reinforce new words with the added power of interactive flashcards.",
+      "myWords": "My Words",
+      "flashcards": "Flashcards",
+      "getStarted": "Get Started",
+      "tryDemo": "Try Demo",
+      "haveAccount": "Already have an account or a Google account?",
+      "logIn": "Log in",
+      "forgotPassword": "Forgot password?"
+    },
+    "features": {
+      "title": "How it works",
+      "subtitle": "Three simple steps to build your vocabulary",
+      "organize": {
+        "title": "Organize",
+        "description": "Keep words tidy like a notebook — only smarter, searchable, and always with you."
+      },
+      "learn": {
+        "title": "Learn",
+        "description": "Use flashcards and spaced repetition to lock new words into long-term memory.",
+        "practiceNow": "Practice now →",
+        "tryDemo": "Try the demo →"
+      },
+      "grow": {
+        "title": "Grow",
+        "description": "Track progress across multiple languages and celebrate your milestones."
+      }
+    },
+    "cta": {
+      "title": "Ready to expand your vocabulary?",
+      "subtitle": "Join for free and start learning today.",
+      "createAccount": "Create Account"
+    }
+  },
+  "demo": {
+    "title": "Try the Flashcard Demo",
+    "subtitle": "Pick a language pair and practice 8 common words — no account needed.",
+    "from": "From",
+    "to": "To",
+    "startPractice": "Start Practice",
+    "wantOwnWords": "Want to practice your own words?",
+    "createFreeAccount": "Create a free account",
+    "change": "Change",
+    "cardProgress": "Card {{ current }} of {{ total }}",
+    "tapHint": "Tap the card to reveal the translation",
+    "skip": "Skip",
+    "right": "Right",
+    "wrong": "Wrong",
+    "skipped": "Skipped",
+    "sessionComplete": "Session complete!",
+    "reviewed": "You reviewed {{ total }} words:",
+    "practiceAgain": "Practice Again",
+    "changeLanguages": "Change Languages",
+    "ctaTitle": "Practice your own vocabulary",
+    "ctaSubtitle": "Create a free account to add your own words and track your progress across sessions.",
+    "createFreeAccountBtn": "Create Free Account",
+    "alreadyHaveAccount": "Already have an account?",
+    "logIn": "Log in"
+  },
+  "register": {
+    "title": "Register to Vocabulary",
+    "subtitle": "Create your account to get started",
+    "username": "Username",
+    "usernamePlaceholder": "Choose a username",
+    "usernameInvalid": "Please enter a valid username",
+    "firstName": "First Name",
+    "firstNameInvalid": "Please enter a valid first name",
+    "lastName": "Last Name",
+    "lastNameInvalid": "Please enter a valid last name",
+    "email": "E-mail",
+    "emailPlaceholder": "you@example.com",
+    "emailInvalid": "Please enter a valid e-mail",
+    "creating": "Creating your account...",
+    "submit": "Register",
+    "orSkip": "Or skip registration and sign in directly",
+    "loginGoogle": "Log in with Google",
+    "successMessage": "✅ Check your email to complete registration.",
+    "errorMessage": "❌ Something went wrong."
+  }
+}

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1,0 +1,98 @@
+{
+  "header": {
+    "home": "Inicio",
+    "words": "Palabras",
+    "myWords": "Mis palabras",
+    "addWord": "Añadir palabra",
+    "flashcards": "Tarjetas",
+    "settings": "Ajustes",
+    "myLanguages": "Mis idiomas",
+    "roles": "Roles",
+    "deleteAccount": "Eliminar cuenta",
+    "login": "Iniciar sesión",
+    "register": "Registrarse",
+    "logout": "Cerrar sesión"
+  },
+  "landing": {
+    "hero": {
+      "title": "Vocabulary Builder",
+      "subtitle": "La esencia del vocabulario tradicional en papel, ahora en formato digital.",
+      "description": "Organiza, aprende y refuerza nuevas palabras con el poder de las tarjetas interactivas.",
+      "myWords": "Mis palabras",
+      "flashcards": "Tarjetas",
+      "getStarted": "Comenzar",
+      "tryDemo": "Probar demo",
+      "haveAccount": "¿Ya tienes una cuenta o una cuenta de Google?",
+      "logIn": "Iniciar sesión",
+      "forgotPassword": "¿Olvidaste tu contraseña?"
+    },
+    "features": {
+      "title": "Cómo funciona",
+      "subtitle": "Tres sencillos pasos para construir tu vocabulario",
+      "organize": {
+        "title": "Organiza",
+        "description": "Mantén las palabras ordenadas como en un cuaderno — pero más inteligente, buscable y siempre contigo."
+      },
+      "learn": {
+        "title": "Aprende",
+        "description": "Usa tarjetas y repetición espaciada para fijar nuevas palabras en la memoria a largo plazo.",
+        "practiceNow": "Practicar ahora →",
+        "tryDemo": "Probar la demo →"
+      },
+      "grow": {
+        "title": "Crece",
+        "description": "Sigue tu progreso en varios idiomas y celebra tus logros."
+      }
+    },
+    "cta": {
+      "title": "¿Listo para ampliar tu vocabulario?",
+      "subtitle": "Regístrate gratis y empieza a aprender hoy.",
+      "createAccount": "Crear cuenta"
+    }
+  },
+  "demo": {
+    "title": "Prueba la demo de tarjetas",
+    "subtitle": "Elige un par de idiomas y practica 8 palabras comunes — sin cuenta.",
+    "from": "De",
+    "to": "A",
+    "startPractice": "Comenzar práctica",
+    "wantOwnWords": "¿Quieres practicar con tus propias palabras?",
+    "createFreeAccount": "Crea una cuenta gratuita",
+    "change": "Cambiar",
+    "cardProgress": "Tarjeta {{ current }} de {{ total }}",
+    "tapHint": "Toca la tarjeta para ver la traducción",
+    "skip": "Saltar",
+    "right": "Correcto",
+    "wrong": "Incorrecto",
+    "skipped": "Omitidas",
+    "sessionComplete": "¡Sesión completada!",
+    "reviewed": "Repasaste {{ total }} palabras:",
+    "practiceAgain": "Practicar de nuevo",
+    "changeLanguages": "Cambiar idiomas",
+    "ctaTitle": "Practica con tu propio vocabulario",
+    "ctaSubtitle": "Crea una cuenta gratuita para añadir tus propias palabras y seguir tu progreso entre sesiones.",
+    "createFreeAccountBtn": "Crear cuenta gratuita",
+    "alreadyHaveAccount": "¿Ya tienes una cuenta?",
+    "logIn": "Iniciar sesión"
+  },
+  "register": {
+    "title": "Regístrate en Vocabulary",
+    "subtitle": "Crea tu cuenta para empezar",
+    "username": "Nombre de usuario",
+    "usernamePlaceholder": "Elige un nombre de usuario",
+    "usernameInvalid": "Por favor, introduce un nombre de usuario válido",
+    "firstName": "Nombre",
+    "firstNameInvalid": "Por favor, introduce un nombre válido",
+    "lastName": "Apellido",
+    "lastNameInvalid": "Por favor, introduce un apellido válido",
+    "email": "Correo electrónico",
+    "emailPlaceholder": "tu@ejemplo.com",
+    "emailInvalid": "Por favor, introduce un correo electrónico válido",
+    "creating": "Creando tu cuenta...",
+    "submit": "Registrarse",
+    "orSkip": "O inicia sesión directamente sin registrarte",
+    "loginGoogle": "Iniciar sesión con Google",
+    "successMessage": "✅ Revisa tu correo para completar el registro.",
+    "errorMessage": "❌ Algo salió mal."
+  }
+}

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -1,0 +1,98 @@
+{
+  "header": {
+    "home": "Home",
+    "words": "Parole",
+    "myWords": "Le mie parole",
+    "addWord": "Aggiungi parola",
+    "flashcards": "Flashcard",
+    "settings": "Impostazioni",
+    "myLanguages": "Le mie lingue",
+    "roles": "Ruoli",
+    "deleteAccount": "Elimina account",
+    "login": "Accedi",
+    "register": "Registrati",
+    "logout": "Esci"
+  },
+  "landing": {
+    "hero": {
+      "title": "Vocabulary Builder",
+      "subtitle": "L'essenza del vocabolario cartaceo tradizionale in formato digitale.",
+      "description": "Organizza, impara e consolida nuove parole con la potenza delle flashcard interattive.",
+      "myWords": "Le mie parole",
+      "flashcards": "Flashcard",
+      "getStarted": "Inizia ora",
+      "tryDemo": "Prova la demo",
+      "haveAccount": "Hai già un account o un account Google?",
+      "logIn": "Accedi",
+      "forgotPassword": "Password dimenticata?"
+    },
+    "features": {
+      "title": "Come funziona",
+      "subtitle": "Tre semplici passi per costruire il tuo vocabolario",
+      "organize": {
+        "title": "Organizza",
+        "description": "Tieni le parole in ordine come un quaderno — ma più smart, ricercabile e sempre con te."
+      },
+      "learn": {
+        "title": "Impara",
+        "description": "Usa le flashcard e la ripetizione spaziata per memorizzare nuove parole a lungo termine.",
+        "practiceNow": "Allenati ora →",
+        "tryDemo": "Prova la demo →"
+      },
+      "grow": {
+        "title": "Cresci",
+        "description": "Monitora i progressi in più lingue e festeggia i tuoi traguardi."
+      }
+    },
+    "cta": {
+      "title": "Pronto ad arricchire il tuo vocabolario?",
+      "subtitle": "Registrati gratis e inizia ad imparare oggi.",
+      "createAccount": "Crea account"
+    }
+  },
+  "demo": {
+    "title": "Prova la demo con le Flashcard",
+    "subtitle": "Scegli una coppia di lingue e pratica 8 parole comuni — senza account.",
+    "from": "Da",
+    "to": "A",
+    "startPractice": "Inizia la pratica",
+    "wantOwnWords": "Vuoi praticare con le tue parole?",
+    "createFreeAccount": "Crea un account gratuito",
+    "change": "Cambia",
+    "cardProgress": "Scheda {{ current }} di {{ total }}",
+    "tapHint": "Tocca la scheda per vedere la traduzione",
+    "skip": "Salta",
+    "right": "Corretto",
+    "wrong": "Sbagliato",
+    "skipped": "Saltati",
+    "sessionComplete": "Sessione completata!",
+    "reviewed": "Hai rivisto {{ total }} parole:",
+    "practiceAgain": "Pratica di nuovo",
+    "changeLanguages": "Cambia lingue",
+    "ctaTitle": "Pratica con il tuo vocabolario",
+    "ctaSubtitle": "Crea un account gratuito per aggiungere le tue parole e seguire i progressi tra le sessioni.",
+    "createFreeAccountBtn": "Crea account gratuito",
+    "alreadyHaveAccount": "Hai già un account?",
+    "logIn": "Accedi"
+  },
+  "register": {
+    "title": "Registrati su Vocabulary",
+    "subtitle": "Crea il tuo account per iniziare",
+    "username": "Nome utente",
+    "usernamePlaceholder": "Scegli un nome utente",
+    "usernameInvalid": "Inserisci un nome utente valido",
+    "firstName": "Nome",
+    "firstNameInvalid": "Inserisci un nome valido",
+    "lastName": "Cognome",
+    "lastNameInvalid": "Inserisci un cognome valido",
+    "email": "E-mail",
+    "emailPlaceholder": "tu@esempio.com",
+    "emailInvalid": "Inserisci un indirizzo e-mail valido",
+    "creating": "Creazione account in corso...",
+    "submit": "Registrati",
+    "orSkip": "Oppure accedi direttamente senza registrarti",
+    "loginGoogle": "Accedi con Google",
+    "successMessage": "✅ Controlla la tua email per completare la registrazione.",
+    "errorMessage": "❌ Qualcosa è andato storto."
+  }
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,8 +1,10 @@
 import { provideRouter, withComponentInputBinding } from '@angular/router';
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, isDevMode, provideZoneChangeDetection } from '@angular/core';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { includeBearerTokenInterceptor } from 'keycloak-angular';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { provideTransloco, provideTranslocoLoader } from '@jsverse/transloco';
+import { I18nLoader } from './shared/service/i18n-loader';
 
 import { provideKeycloakAngular } from './keycloak.config';
 import { routes } from './app.routes';
@@ -14,5 +16,14 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes, withComponentInputBinding()),
     provideHttpClient(withInterceptors([includeBearerTokenInterceptor])),
     provideAnimationsAsync(),
+    provideTransloco({
+      config: {
+        availableLangs: ['en', 'it', 'de', 'es'],
+        defaultLang: localStorage.getItem('lang') ?? 'en',
+        reRenderOnLangChange: true,
+        prodMode: !isDevMode(),
+      },
+    }),
+    provideTranslocoLoader(I18nLoader),
   ]
 };

--- a/src/app/demo-flashcard/demo-flashcard.component.html
+++ b/src/app/demo-flashcard/demo-flashcard.component.html
@@ -5,12 +5,12 @@
   <div class="row justify-content-center">
     <div class="col-md-5 text-center py-4">
       <i class="bi bi-translate fs-1 text-primary"></i>
-      <h3 class="mt-3 fw-bold">Try the Flashcard Demo</h3>
-      <p class="text-muted mb-4">Pick a language pair and practice 8 common words — no account needed.</p>
+      <h3 class="mt-3 fw-bold">{{ 'demo.title' | transloco }}</h3>
+      <p class="text-muted mb-4">{{ 'demo.subtitle' | transloco }}</p>
 
       <div class="row g-3 mb-4 align-items-center">
         <div class="col">
-          <label class="form-label fw-semibold">From</label>
+          <label class="form-label fw-semibold">{{ 'demo.from' | transloco }}</label>
           <select class="form-select form-select-lg" [(ngModel)]="fromLang" (ngModelChange)="onFromChange()">
             @for (lang of languages; track lang.code) {
               <option [value]="lang.code">{{ lang.flag }} {{ lang.name }}</option>
@@ -21,7 +21,7 @@
           <i class="bi bi-arrow-right fs-4 text-muted"></i>
         </div>
         <div class="col">
-          <label class="form-label fw-semibold">To</label>
+          <label class="form-label fw-semibold">{{ 'demo.to' | transloco }}</label>
           <select class="form-select form-select-lg" [(ngModel)]="toLang" (ngModelChange)="onToChange()">
             @for (lang of languages; track lang.code) {
               <option [value]="lang.code" [disabled]="lang.code === fromLang">{{ lang.flag }} {{ lang.name }}</option>
@@ -31,12 +31,12 @@
       </div>
 
       <button class="btn btn-primary btn-lg w-100" (click)="start()" [disabled]="!canStart">
-        <i class="bi bi-play-fill me-2"></i>Start Practice
+        <i class="bi bi-play-fill me-2"></i>{{ 'demo.startPractice' | transloco }}
       </button>
 
       <p class="mt-4 mb-0 small text-muted">
-        Want to practice your own words?
-        <a routerLink="/register" class="fw-semibold">Create a free account</a>
+        {{ 'demo.wantOwnWords' | transloco }}
+        <a routerLink="/register" class="fw-semibold">{{ 'demo.createFreeAccount' | transloco }}</a>
       </p>
     </div>
   </div>
@@ -52,12 +52,12 @@
         <span class="badge bg-primary bg-opacity-10 text-primary fs-6">
           {{ fromLanguage.flag }} {{ fromLanguage.name }} → {{ toLanguage.flag }} {{ toLanguage.name }}
         </span>
-        <button class="btn btn-sm btn-outline-secondary" (click)="changeLang()">Change</button>
+        <button class="btn btn-sm btn-outline-secondary" (click)="changeLang()">{{ 'demo.change' | transloco }}</button>
       </div>
 
       <!-- Progress -->
       <div class="d-flex justify-content-between align-items-center mb-2">
-        <span class="text-muted small">Card {{ currentIndex + 1 }} of {{ words.length }}</span>
+        <span class="text-muted small">{{ 'demo.cardProgress' | transloco: { current: currentIndex + 1, total: words.length } }}</span>
         <div class="d-flex gap-3 small">
           <span class="text-success"><i class="bi bi-check-circle-fill"></i> {{ rightCount }}</span>
           <span class="text-danger"><i class="bi bi-x-circle-fill"></i> {{ wrongCount }}</span>
@@ -70,7 +70,7 @@
       </div>
 
       <!-- Card -->
-      <div class="card-flip-container" (click)="state === 'sentence' && reveal()" [style.cursor]="state === 'sentence' ? 'pointer' : 'default'" [title]="state === 'sentence' ? 'Click to reveal the translation' : ''">
+      <div class="card-flip-container" (click)="state === 'sentence' && reveal()" [style.cursor]="state === 'sentence' ? 'pointer' : 'default'" [title]="state === 'sentence' ? ('demo.tapHint' | transloco) : ''">
         <div class="card-inner" [class.flipped]="isFlipped" [class.no-transition]="skipTransition">
 
           <!-- Front: sentence -->
@@ -94,7 +94,7 @@
       <!-- Hint (first card only) -->
       @if (state === 'sentence' && currentIndex === 0) {
       <p class="text-center text-muted small mb-3">
-        <i class="bi bi-hand-index me-1"></i>Tap the card to reveal the translation
+        <i class="bi bi-hand-index me-1"></i>{{ 'demo.tapHint' | transloco }}
       </p>
       }
 
@@ -103,7 +103,7 @@
       <div class="row g-2">
         <div class="col-12">
           <button class="btn btn-outline-secondary w-100 btn-lg" (click)="submit('SKIP')">
-            <i class="bi bi-arrow-right me-1"></i>Skip
+            <i class="bi bi-arrow-right me-1"></i>{{ 'demo.skip' | transloco }}
           </button>
         </div>
       </div>
@@ -113,12 +113,12 @@
       <div class="row g-2">
         <div class="col-6">
           <button class="btn btn-success w-100 btn-lg" (click)="submit('RIGHT')">
-            <i class="bi bi-check-lg me-1"></i>Right
+            <i class="bi bi-check-lg me-1"></i>{{ 'demo.right' | transloco }}
           </button>
         </div>
         <div class="col-6">
           <button class="btn btn-danger w-100 btn-lg" (click)="submit('WRONG')">
-            <i class="bi bi-x-lg me-1"></i>Wrong
+            <i class="bi bi-x-lg me-1"></i>{{ 'demo.wrong' | transloco }}
           </button>
         </div>
       </div>
@@ -133,9 +133,9 @@
   <div class="row justify-content-center">
     <div class="col-md-6 text-center py-4">
       <i class="bi bi-trophy-fill fs-1 text-warning"></i>
-      <h3 class="mt-3">Session complete!</h3>
+      <h3 class="mt-3">{{ 'demo.sessionComplete' | transloco }}</h3>
       <p class="text-muted">
-        You reviewed {{ words.length }} words:
+        {{ 'demo.reviewed' | transloco: { total: words.length } }}
         {{ fromLanguage.flag }} {{ fromLanguage.name }} → {{ toLanguage.flag }} {{ toLanguage.name }}.
       </p>
 
@@ -143,39 +143,39 @@
         <div class="col-4">
           <div class="card border-0 bg-success bg-opacity-10 py-3">
             <div class="fs-2 fw-bold text-success">{{ rightCount }}</div>
-            <div class="small text-muted">Right</div>
+            <div class="small text-muted">{{ 'demo.right' | transloco }}</div>
           </div>
         </div>
         <div class="col-4">
           <div class="card border-0 bg-danger bg-opacity-10 py-3">
             <div class="fs-2 fw-bold text-danger">{{ wrongCount }}</div>
-            <div class="small text-muted">Wrong</div>
+            <div class="small text-muted">{{ 'demo.wrong' | transloco }}</div>
           </div>
         </div>
         <div class="col-4">
           <div class="card border-0 bg-secondary bg-opacity-10 py-3">
             <div class="fs-2 fw-bold text-secondary">{{ skipCount }}</div>
-            <div class="small text-muted">Skipped</div>
+            <div class="small text-muted">{{ 'demo.skipped' | transloco }}</div>
           </div>
         </div>
       </div>
 
       <div class="d-flex gap-2 justify-content-center mt-3">
         <button class="btn btn-outline-primary" (click)="restart()">
-          <i class="bi bi-arrow-clockwise me-2"></i>Practice Again
+          <i class="bi bi-arrow-clockwise me-2"></i>{{ 'demo.practiceAgain' | transloco }}
         </button>
-        <button class="btn btn-outline-secondary" (click)="changeLang()">Change Languages</button>
+        <button class="btn btn-outline-secondary" (click)="changeLang()">{{ 'demo.changeLanguages' | transloco }}</button>
       </div>
 
       <!-- Sign-up CTA -->
       <div class="card border-0 bg-primary bg-opacity-10 mt-4 p-4">
-        <h5 class="fw-bold mb-2">Practice your own vocabulary</h5>
-        <p class="text-muted small mb-3">Create a free account to add your own words and track your progress across sessions.</p>
+        <h5 class="fw-bold mb-2">{{ 'demo.ctaTitle' | transloco }}</h5>
+        <p class="text-muted small mb-3">{{ 'demo.ctaSubtitle' | transloco }}</p>
         <a routerLink="/register" class="btn btn-primary">
-          <i class="bi bi-person-plus me-2"></i>Create Free Account
+          <i class="bi bi-person-plus me-2"></i>{{ 'demo.createFreeAccountBtn' | transloco }}
         </a>
         <p class="mt-2 mb-0 small text-muted">
-          Already have an account? <a routerLink="/">Log in</a>
+          {{ 'demo.alreadyHaveAccount' | transloco }} <a routerLink="/">{{ 'demo.logIn' | transloco }}</a>
         </p>
       </div>
 

--- a/src/app/demo-flashcard/demo-flashcard.component.ts
+++ b/src/app/demo-flashcard/demo-flashcard.component.ts
@@ -4,6 +4,7 @@ import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { WordView, WordReviewResultType } from '../shared/model/flashcard.model';
 import { DEMO_LANGUAGES, DemoLangCode, DemoLanguage, getDemoWords } from '../shared/data/demo-words';
+import { TranslocoModule } from '@jsverse/transloco';
 
 type SessionState = 'pick-language' | 'sentence' | 'translation' | 'complete';
 
@@ -15,7 +16,7 @@ interface ReviewEntry {
 @Component({
   selector: 'app-demo-flashcard',
   standalone: true,
-  imports: [CommonModule, RouterLink, FormsModule],
+  imports: [CommonModule, RouterLink, FormsModule, TranslocoModule],
   templateUrl: './demo-flashcard.component.html',
   styleUrl: './demo-flashcard.component.css',
 })

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,7 +1,7 @@
 <mat-toolbar class="sticky-top px-2 px-md-3 bg-dark text-white"
   [class.shadow]="isScrolled">
 
-  
+
   <a routerLink="/" mat-button class="rounded-pill fw-bold fs-6 text-white" (click)="closeMobileMenu()">
     <mat-icon class="text-white">auto_stories</mat-icon>
     Vocabulary
@@ -9,74 +9,93 @@
 
   <span class="flex-fill"></span>
 
-  
+
   <nav class="d-none d-lg-flex align-items-center gap-1">
 
     <a routerLink="/" mat-button class="rounded-pill text-white"
       routerLinkActive="bg-white bg-opacity-10"
       [routerLinkActiveOptions]="{exact:true}">
-      <mat-icon class="text-white">home</mat-icon> Home
+      <mat-icon class="text-white">home</mat-icon> {{ 'header.home' | transloco }}
     </a>
 
     <ng-container *kaHasRoles="['USER']">
       <button mat-button class="rounded-pill text-white" [matMenuTriggerFor]="wordsMenu">
         <mat-icon class="text-white">library_books</mat-icon>
-        Words
+        {{ 'header.words' | transloco }}
         <mat-icon class="text-white" iconPositionEnd>arrow_drop_down</mat-icon>
       </button>
       <mat-menu #wordsMenu="matMenu">
         <a mat-menu-item routerLink="/word/list">
-          <mat-icon>format_list_bulleted</mat-icon> My Words
+          <mat-icon>format_list_bulleted</mat-icon> {{ 'header.myWords' | transloco }}
         </a>
         <a mat-menu-item routerLink="/word/new-word">
-          <mat-icon>add_circle</mat-icon> Add Word
+          <mat-icon>add_circle</mat-icon> {{ 'header.addWord' | transloco }}
         </a>
       </mat-menu>
     </ng-container>
 
     <a *kaHasRoles="['USER']" routerLink="/flashcard" mat-button class="rounded-pill text-white"
       routerLinkActive="bg-white bg-opacity-10">
-      <mat-icon class="text-white">style</mat-icon> Flashcards
+      <mat-icon class="text-white">style</mat-icon> {{ 'header.flashcards' | transloco }}
     </a>
 
     <ng-container *kaHasRoles="['USER']">
       <button mat-button class="rounded-pill text-white" [matMenuTriggerFor]="settingsMenu">
         <mat-icon class="text-white">tune</mat-icon>
-        Settings
+        {{ 'header.settings' | transloco }}
         <mat-icon class="text-white" iconPositionEnd>arrow_drop_down</mat-icon>
       </button>
       <mat-menu #settingsMenu="matMenu">
         <a mat-menu-item routerLink="/settings/languages">
-          <mat-icon>language</mat-icon> My Languages
+          <mat-icon>language</mat-icon> {{ 'header.myLanguages' | transloco }}
         </a>
         <a mat-menu-item routerLink="/settings/roles">
-          <mat-icon>manage_accounts</mat-icon> Roles
+          <mat-icon>manage_accounts</mat-icon> {{ 'header.roles' | transloco }}
         </a>
         <mat-divider></mat-divider>
         <a mat-menu-item routerLink="/settings/delete-user">
-          <mat-icon color="warn">delete_forever</mat-icon> Delete Account
+          <mat-icon color="warn">delete_forever</mat-icon> {{ 'header.deleteAccount' | transloco }}
         </a>
       </mat-menu>
     </ng-container>
 
     <div class="vr text-white opacity-25 mx-2 d-none d-lg-inline-flex"></div>
 
+    <!-- Language switcher -->
+    <button mat-button class="rounded-pill text-white" [matMenuTriggerFor]="langMenu">
+      <mat-icon class="text-white">language</mat-icon>
+      {{ activeLang.toUpperCase() }}
+    </button>
+    <mat-menu #langMenu="matMenu">
+      @for (lang of langs; track lang.code) {
+        <button mat-menu-item (click)="setLang(lang.code)">
+          @if (activeLang === lang.code) {
+            <mat-icon color="primary">check</mat-icon>
+          } @else {
+            <mat-icon></mat-icon>
+          }
+          <span [class.fw-bold]="activeLang === lang.code"
+                [class.text-primary]="activeLang === lang.code">{{ lang.label }}</span>
+        </button>
+      }
+    </mat-menu>
+
     @if (!authenticated) {
       <button mat-button class="rounded-pill text-white" (click)="login()">
-        <mat-icon class="text-white">login</mat-icon> Login
+        <mat-icon class="text-white">login</mat-icon> {{ 'header.login' | transloco }}
       </button>
       <a mat-raised-button routerLink="/register" class="rounded-pill ms-1 bg-gradient bg-primary text-white fw-semibold">
-        <mat-icon class="text-white">person_add</mat-icon> Register
+        <mat-icon class="text-white">person_add</mat-icon> {{ 'header.register' | transloco }}
       </a>
     } @else {
       <button mat-stroked-button class="rounded-pill border-white border-opacity-50 text-white" (click)="logout()">
-        <mat-icon class="text-white">logout</mat-icon> Logout
+        <mat-icon class="text-white">logout</mat-icon> {{ 'header.logout' | transloco }}
       </button>
     }
 
   </nav>
 
-  
+
   <button mat-icon-button class="d-lg-none text-white" (click)="mobileMenuOpen = !mobileMenuOpen">
     <mat-icon class="text-white">{{ mobileMenuOpen ? 'close' : 'menu' }}</mat-icon>
   </button>
@@ -90,21 +109,21 @@
     <a mat-button class="d-flex w-100 justify-content-start rounded-pill mb-1 text-white"
       routerLink="/" routerLinkActive="bg-white bg-opacity-10"
       [routerLinkActiveOptions]="{exact:true}" (click)="closeMobileMenu()">
-      <mat-icon class="me-2 text-white">home</mat-icon> Home
+      <mat-icon class="me-2 text-white">home</mat-icon> {{ 'header.home' | transloco }}
     </a>
 
     <ng-container *kaHasRoles="['USER']">
       <a mat-button class="d-flex w-100 justify-content-start rounded-pill mb-1 text-white"
         routerLink="/word/list" routerLinkActive="bg-white bg-opacity-10" (click)="closeMobileMenu()">
-        <mat-icon class="me-2 text-white">format_list_bulleted</mat-icon> My Words
+        <mat-icon class="me-2 text-white">format_list_bulleted</mat-icon> {{ 'header.myWords' | transloco }}
       </a>
       <a mat-button class="d-flex w-100 justify-content-start rounded-pill mb-1 text-white"
         routerLink="/word/new-word" routerLinkActive="bg-white bg-opacity-10" (click)="closeMobileMenu()">
-        <mat-icon class="me-2 text-white">add_circle</mat-icon> Add Word
+        <mat-icon class="me-2 text-white">add_circle</mat-icon> {{ 'header.addWord' | transloco }}
       </a>
       <a mat-button class="d-flex w-100 justify-content-start rounded-pill mb-1 text-white"
         routerLink="/flashcard" routerLinkActive="bg-white bg-opacity-10" (click)="closeMobileMenu()">
-        <mat-icon class="me-2 text-white">style</mat-icon> Flashcards
+        <mat-icon class="me-2 text-white">style</mat-icon> {{ 'header.flashcards' | transloco }}
       </a>
     </ng-container>
 
@@ -113,28 +132,42 @@
     <ng-container *kaHasRoles="['USER']">
       <a mat-button class="d-flex w-100 justify-content-start rounded-pill mb-1 text-white"
         routerLink="/settings/languages" routerLinkActive="bg-white bg-opacity-10" (click)="closeMobileMenu()">
-        <mat-icon class="me-2 text-white">language</mat-icon> My Languages
+        <mat-icon class="me-2 text-white">language</mat-icon> {{ 'header.myLanguages' | transloco }}
       </a>
       <a mat-button class="d-flex w-100 justify-content-start rounded-pill mb-1 text-white"
         routerLink="/settings/roles" routerLinkActive="bg-white bg-opacity-10" (click)="closeMobileMenu()">
-        <mat-icon class="me-2 text-white">manage_accounts</mat-icon> Roles
+        <mat-icon class="me-2 text-white">manage_accounts</mat-icon> {{ 'header.roles' | transloco }}
       </a>
       <mat-divider class="my-2"></mat-divider>
     </ng-container>
 
+    <!-- Language switcher (mobile) -->
+    <div class="d-flex gap-1 mb-2 px-1">
+      @for (lang of langs; track lang.code) {
+        <button mat-flat-button class="flex-fill"
+          [color]="activeLang === lang.code ? 'primary' : undefined"
+          [class.text-white]="activeLang !== lang.code"
+          [class.border-white]="activeLang !== lang.code"
+          [class.border-opacity-25]="activeLang !== lang.code"
+          (click)="setLang(lang.code)">
+          {{ lang.code.toUpperCase() }}
+        </button>
+      }
+    </div>
+
     @if (!authenticated) {
       <button mat-button class="d-flex w-100 justify-content-start rounded-pill mb-1 text-white"
         (click)="login(); closeMobileMenu()">
-        <mat-icon class="me-2 text-white">login</mat-icon> Login
+        <mat-icon class="me-2 text-white">login</mat-icon> {{ 'header.login' | transloco }}
       </button>
       <a mat-raised-button class="d-flex w-100 justify-content-start rounded-pill bg-gradient bg-primary text-white"
         routerLink="/register" (click)="closeMobileMenu()">
-        <mat-icon class="me-2 text-white">person_add</mat-icon> Register
+        <mat-icon class="me-2 text-white">person_add</mat-icon> {{ 'header.register' | transloco }}
       </a>
     } @else {
       <button mat-stroked-button class="d-flex w-100 justify-content-start rounded-pill text-white border-white border-opacity-50"
         (click)="logout()">
-        <mat-icon class="me-2 text-white">logout</mat-icon> Logout
+        <mat-icon class="me-2 text-white">logout</mat-icon> {{ 'header.logout' | transloco }}
       </button>
     }
 

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -14,6 +14,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDividerModule } from '@angular/material/divider';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 
 @Component({
   selector: 'app-header',
@@ -27,6 +28,7 @@ import { MatDividerModule } from '@angular/material/divider';
     MatMenuModule,
     MatTooltipModule,
     MatDividerModule,
+    TranslocoModule,
   ],
   templateUrl: './header.component.html',
 })
@@ -35,8 +37,20 @@ export class HeaderComponent {
   isScrolled = false;
   mobileMenuOpen = false;
 
+  readonly langs = [
+    { code: 'en', label: 'English' },
+    { code: 'it', label: 'Italiano' },
+    { code: 'de', label: 'Deutsch' },
+    { code: 'es', label: 'Español' },
+  ];
+
   private readonly keycloak = inject(Keycloak);
   private readonly keycloakSignal = inject(KEYCLOAK_EVENT_SIGNAL);
+  private readonly transloco = inject(TranslocoService);
+
+  get activeLang(): string {
+    return this.transloco.getActiveLang();
+  }
 
   constructor() {
     effect(() => {
@@ -53,6 +67,11 @@ export class HeaderComponent {
   @HostListener('window:scroll')
   onScroll(): void {
     this.isScrolled = window.scrollY > 4;
+  }
+
+  setLang(code: string): void {
+    this.transloco.setActiveLang(code);
+    localStorage.setItem('lang', code);
   }
 
   login(): void { this.keycloak.login(); }

--- a/src/app/landing/landing.component.html
+++ b/src/app/landing/landing.component.html
@@ -5,21 +5,21 @@
   <div class="container">
     <div class="row align-items-center g-5">
       <div class="col-lg-6 text-center text-lg-start">
-        <h1 class="fw-bold mb-2 mb-lg-3" style="font-size: clamp(1.1rem, 5vw, 3.5rem);">Vocabulary Builder</h1>
-        <p class="mb-2 mb-lg-3 opacity-90 d-none d-lg-block" style="font-size: clamp(0.8rem, 2.5vw, 1.25rem);">Embrace the essence of traditional paper vocabularies in a digital format.</p>
-        <p class="mb-3 mb-lg-4 opacity-75 d-none d-lg-block">Effortlessly organize, learn, and reinforce new words with the added power of interactive flashcards.</p>
+        <h1 class="fw-bold mb-2 mb-lg-3" style="font-size: clamp(1.1rem, 5vw, 3.5rem);">{{ 'landing.hero.title' | transloco }}</h1>
+        <p class="mb-2 mb-lg-3 opacity-90 d-none d-lg-block" style="font-size: clamp(0.8rem, 2.5vw, 1.25rem);">{{ 'landing.hero.subtitle' | transloco }}</p>
+        <p class="mb-3 mb-lg-4 opacity-75 d-none d-lg-block">{{ 'landing.hero.description' | transloco }}</p>
         <div class="d-flex gap-2 justify-content-center justify-content-lg-start">
           @if (authenticated) {
-            <a routerLink="/word/list" class="btn btn-light btn-sm px-2 px-lg-4 fw-semibold" style="font-size: clamp(0.75rem, 2.5vw, 1rem);">My Words</a>
-            <a routerLink="/flashcard" class="btn btn-outline-light btn-sm px-2 px-lg-4 fw-semibold" style="font-size: clamp(0.75rem, 2.5vw, 1rem);">Flashcards</a>
+            <a routerLink="/word/list" class="btn btn-light btn-sm px-2 px-lg-4 fw-semibold" style="font-size: clamp(0.75rem, 2.5vw, 1rem);">{{ 'landing.hero.myWords' | transloco }}</a>
+            <a routerLink="/flashcard" class="btn btn-outline-light btn-sm px-2 px-lg-4 fw-semibold" style="font-size: clamp(0.75rem, 2.5vw, 1rem);">{{ 'landing.hero.flashcards' | transloco }}</a>
           } @else {
-            <a routerLink="/register" class="btn btn-light btn-sm px-2 px-lg-4 fw-semibold" style="font-size: clamp(0.75rem, 2.5vw, 1rem);">Get Started</a>
-            <a routerLink="/demo" class="btn btn-outline-light btn-sm px-2 px-lg-4 fw-semibold" style="font-size: clamp(0.75rem, 2.5vw, 1rem);">Try Demo</a>
+            <a routerLink="/register" class="btn btn-light btn-sm px-2 px-lg-4 fw-semibold" style="font-size: clamp(0.75rem, 2.5vw, 1rem);">{{ 'landing.hero.getStarted' | transloco }}</a>
+            <a routerLink="/demo" class="btn btn-outline-light btn-sm px-2 px-lg-4 fw-semibold" style="font-size: clamp(0.75rem, 2.5vw, 1rem);">{{ 'landing.hero.tryDemo' | transloco }}</a>
           }
         </div>
         @if (!authenticated) {
-          <p class="mt-2 mt-lg-3 mb-0 small opacity-75">Already have an account or a Google account? <a (click)="login()" role="button" class="text-white fw-semibold" style="cursor: pointer; text-decoration: underline;">Log in</a></p>
-          <p class="mb-0 small opacity-50"><a (click)="forgotPassword()" role="button" class="text-white" style="cursor: pointer; text-decoration: underline;">Forgot password?</a></p>
+          <p class="mt-2 mt-lg-3 mb-0 small opacity-75">{{ 'landing.hero.haveAccount' | transloco }} <a (click)="login()" role="button" class="text-white fw-semibold" style="cursor: pointer; text-decoration: underline;">{{ 'landing.hero.logIn' | transloco }}</a></p>
+          <p class="mb-0 small opacity-50"><a (click)="forgotPassword()" role="button" class="text-white" style="cursor: pointer; text-decoration: underline;">{{ 'landing.hero.forgotPassword' | transloco }}</a></p>
         }
       </div>
       <div class="col-lg-6 text-center position-relative d-none d-lg-block" style="height: 350px;">
@@ -39,8 +39,8 @@
 <!-- Features -->
 <section class="py-3 py-md-5">
   <div class="container">
-    <h2 class="text-center fw-bold mb-2">How it works</h2>
-    <p class="text-center text-body-secondary mb-3 mb-md-5">Three simple steps to build your vocabulary</p>
+    <h2 class="text-center fw-bold mb-2">{{ 'landing.features.title' | transloco }}</h2>
+    <p class="text-center text-body-secondary mb-3 mb-md-5">{{ 'landing.features.subtitle' | transloco }}</p>
     <div class="row g-2 g-md-4">
       <div class="col-4">
         <div class="card shadow-sm border-0 bg-light text-center">
@@ -49,11 +49,11 @@
             <div class="bg-primary bg-opacity-10 rounded-circle d-inline-flex align-items-center justify-content-center mb-1 mb-md-3" style="width: clamp(40px, 8vw, 64px); height: clamp(40px, 8vw, 64px);">
               <i class="bi bi-book-half text-primary" style="font-size: clamp(1rem, 3vw, 1.5rem);"></i>
             </div>
-            <h6 class="fw-semibold mb-0">Organize</h6>
+            <h6 class="fw-semibold mb-0">{{ 'landing.features.organize.title' | transloco }}</h6>
             <i class="bi bi-chevron-down chevron d-md-none small text-body-secondary"></i>
           </div>
           <div class="collapse d-md-block px-2 pb-2" id="organizeDesc">
-            <p class="text-body-secondary mb-0 small">Keep words tidy like a notebook — only smarter, searchable, and always with you.</p>
+            <p class="text-body-secondary mb-0 small">{{ 'landing.features.organize.description' | transloco }}</p>
           </div>
         </div>
       </div>
@@ -64,15 +64,15 @@
             <div class="bg-success bg-opacity-10 rounded-circle d-inline-flex align-items-center justify-content-center mb-1 mb-md-3" style="width: clamp(40px, 8vw, 64px); height: clamp(40px, 8vw, 64px);">
               <i class="bi bi-lightning-charge text-success" style="font-size: clamp(1rem, 3vw, 1.5rem);"></i>
             </div>
-            <h6 class="fw-semibold mb-0">Learn</h6>
+            <h6 class="fw-semibold mb-0">{{ 'landing.features.learn.title' | transloco }}</h6>
             <i class="bi bi-chevron-down chevron d-md-none small text-body-secondary"></i>
           </div>
           <div class="collapse d-md-block px-2 pb-2" id="learnDesc">
-            <p class="text-body-secondary mb-1 small">Use flashcards and spaced repetition to lock new words into long-term memory.</p>
+            <p class="text-body-secondary mb-1 small">{{ 'landing.features.learn.description' | transloco }}</p>
             @if (authenticated) {
-              <a routerLink="/flashcard" class="small fw-semibold text-success">Practice now →</a>
+              <a routerLink="/flashcard" class="small fw-semibold text-success">{{ 'landing.features.learn.practiceNow' | transloco }}</a>
             } @else {
-              <a routerLink="/demo" class="small fw-semibold text-success">Try the demo →</a>
+              <a routerLink="/demo" class="small fw-semibold text-success">{{ 'landing.features.learn.tryDemo' | transloco }}</a>
             }
           </div>
         </div>
@@ -84,11 +84,11 @@
             <div class="bg-danger bg-opacity-10 rounded-circle d-inline-flex align-items-center justify-content-center mb-1 mb-md-3" style="width: clamp(40px, 8vw, 64px); height: clamp(40px, 8vw, 64px);">
               <i class="bi bi-globe text-danger" style="font-size: clamp(1rem, 3vw, 1.5rem);"></i>
             </div>
-            <h6 class="fw-semibold mb-0">Grow</h6>
+            <h6 class="fw-semibold mb-0">{{ 'landing.features.grow.title' | transloco }}</h6>
             <i class="bi bi-chevron-down chevron d-md-none small text-body-secondary"></i>
           </div>
           <div class="collapse d-md-block px-2 pb-2" id="growDesc">
-            <p class="text-body-secondary mb-0 small">Track progress across multiple languages and celebrate your milestones.</p>
+            <p class="text-body-secondary mb-0 small">{{ 'landing.features.grow.description' | transloco }}</p>
           </div>
         </div>
       </div>
@@ -100,9 +100,9 @@
 @if (!authenticated) {
 <section class="py-5 bg-light">
   <div class="container text-center">
-    <h2 class="fw-bold mb-3">Ready to expand your vocabulary?</h2>
-    <p class="text-body-secondary mb-4">Join for free and start learning today.</p>
-    <a routerLink="/register" class="btn btn-primary btn-lg px-5">Create Account</a>
+    <h2 class="fw-bold mb-3">{{ 'landing.cta.title' | transloco }}</h2>
+    <p class="text-body-secondary mb-4">{{ 'landing.cta.subtitle' | transloco }}</p>
+    <a routerLink="/register" class="btn btn-primary btn-lg px-5">{{ 'landing.cta.createAccount' | transloco }}</a>
   </div>
 </section>
 }

--- a/src/app/landing/landing.component.ts
+++ b/src/app/landing/landing.component.ts
@@ -8,10 +8,11 @@ import {
   typeEventArgs,
   ReadyArgs
 } from 'keycloak-angular';
+import { TranslocoModule } from '@jsverse/transloco';
 
 @Component({
   selector: 'app-landing',
-  imports: [RouterLink, DisclaimerComponent],
+  imports: [RouterLink, DisclaimerComponent, TranslocoModule],
   templateUrl: './landing.component.html',
   styleUrl: './landing.component.css'
 })

--- a/src/app/shared/service/i18n-loader.ts
+++ b/src/app/shared/service/i18n-loader.ts
@@ -1,0 +1,12 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Translation, TranslocoLoader } from '@jsverse/transloco';
+
+@Injectable({ providedIn: 'root' })
+export class I18nLoader implements TranslocoLoader {
+  private readonly http = inject(HttpClient);
+
+  getTranslation(lang: string) {
+    return this.http.get<Translation>(`/i18n/${lang}.json`);
+  }
+}

--- a/src/app/user/new-user/new-user.component.html
+++ b/src/app/user/new-user/new-user.component.html
@@ -4,28 +4,28 @@
 
       <div class="card shadow-sm">
         <div class="card-body p-4">
-          <h2 class="card-title fw-bold mb-1">Register to Vocabulary</h2>
-          <p class="text-body-secondary mb-4">Create your account to get started</p>
+          <h2 class="card-title fw-bold mb-1">{{ 'register.title' | transloco }}</h2>
+          <p class="text-body-secondary mb-4">{{ 'register.subtitle' | transloco }}</p>
 
           <form [formGroup]="form" (ngSubmit)="onSubmit()">
 
             <div class="mb-3">
-              <label for="username" class="form-label">Username</label>
+              <label for="username" class="form-label">{{ 'register.username' | transloco }}</label>
               <input
                 id="username"
                 type="text"
                 [formControl]="form.controls.username"
                 class="form-control"
-                placeholder="Choose a username"
+                [placeholder]="'register.usernamePlaceholder' | transloco"
               />
               @if (usernamesInvalid) {
-                <div class="text-danger small mt-1">Please enter a valid username</div>
+                <div class="text-danger small mt-1">{{ 'register.usernameInvalid' | transloco }}</div>
               }
             </div>
 
             <div class="row g-3 mb-3">
               <div class="col-6">
-                <label for="firstName" class="form-label">First Name</label>
+                <label for="firstName" class="form-label">{{ 'register.firstName' | transloco }}</label>
                 <input
                   id="firstName"
                   type="text"
@@ -33,11 +33,11 @@
                   class="form-control"
                 />
                 @if (firstNameIsInvalid) {
-                  <div class="text-danger small mt-1">Please enter a valid first name</div>
+                  <div class="text-danger small mt-1">{{ 'register.firstNameInvalid' | transloco }}</div>
                 }
               </div>
               <div class="col-6">
-                <label for="lastName" class="form-label">Last Name</label>
+                <label for="lastName" class="form-label">{{ 'register.lastName' | transloco }}</label>
                 <input
                   id="lastName"
                   type="text"
@@ -45,22 +45,22 @@
                   class="form-control"
                 />
                 @if (lastNameIsInvalid) {
-                  <div class="text-danger small mt-1">Please enter a valid last name</div>
+                  <div class="text-danger small mt-1">{{ 'register.lastNameInvalid' | transloco }}</div>
                 }
               </div>
             </div>
 
             <div class="mb-4">
-              <label for="email" class="form-label">E-mail</label>
+              <label for="email" class="form-label">{{ 'register.email' | transloco }}</label>
               <input
                 id="email"
                 type="email"
                 [formControl]="form.controls.email"
                 class="form-control"
-                placeholder="you@example.com"
+                [placeholder]="'register.emailPlaceholder' | transloco"
               />
               @if (emailIsInvalid) {
-                <div class="text-danger small mt-1">Please enter a valid e-mail</div>
+                <div class="text-danger small mt-1">{{ 'register.emailInvalid' | transloco }}</div>
               }
             </div>
 
@@ -71,9 +71,9 @@
             }
 
             @if (isLoading) {
-              <div class="text-center text-body-secondary">Creating your account...</div>
+              <div class="text-center text-body-secondary">{{ 'register.creating' | transloco }}</div>
             } @else if (!registrationSuccess) {
-              <button type="submit" class="btn btn-primary w-100" [disabled]="isSubmitDisabled">Register</button>
+              <button type="submit" class="btn btn-primary w-100" [disabled]="isSubmitDisabled">{{ 'register.submit' | transloco }}</button>
             }
 
             @if (message) {
@@ -87,9 +87,9 @@
           <hr class="my-4">
 
           <div class="text-center">
-            <p class="text-body-secondary small mb-2">Or skip registration and sign in directly</p>
+            <p class="text-body-secondary small mb-2">{{ 'register.orSkip' | transloco }}</p>
             <button (click)="login()" class="btn btn-outline-secondary w-100">
-              <i class="bi bi-google me-2"></i>Log in with Google
+              <i class="bi bi-google me-2"></i>{{ 'register.loginGoogle' | transloco }}
             </button>
           </div>
 

--- a/src/app/user/new-user/new-user.component.ts
+++ b/src/app/user/new-user/new-user.component.ts
@@ -11,11 +11,12 @@ import { CommonModule } from '@angular/common';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import Keycloak from 'keycloak-js';
 import { environment } from '../../../environments/environment';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 
 @Component({
   selector: 'app-new-user',
 
-  imports: [ReactiveFormsModule, CommonModule],
+  imports: [ReactiveFormsModule, CommonModule, TranslocoModule],
 
   templateUrl: './new-user.component.html',
   styleUrl: './new-user.component.css',
@@ -24,6 +25,7 @@ export class NewUserComponent implements AfterViewInit, OnDestroy {
   private readonly userService = inject(UserService);
   private readonly keycloak = inject(Keycloak);
   private readonly ngZone = inject(NgZone);
+  private readonly transloco = inject(TranslocoService);
 
   readonly captchaEnabled = !!environment.turnstileSiteKey;
   private readonly turnstileSiteKey = environment.turnstileSiteKey;
@@ -105,7 +107,7 @@ export class NewUserComponent implements AfterViewInit, OnDestroy {
           this.isError = false;
           this.registrationSuccess = true;
           this.form.disable();
-          this.message = '✅ Check your email to complete registration.';
+          this.message = this.transloco.translate('register.successMessage');
         } else {
           this.isError = true;
           this.message = `Unexpected status: ${response.status}`;
@@ -116,7 +118,7 @@ export class NewUserComponent implements AfterViewInit, OnDestroy {
         this.isLoading = false;
         this.isError = true;
         const body = error.error;
-        this.message = (body && body.message) ? body.message : '❌ Something went wrong.';
+        this.message = (body && body.message) ? body.message : this.transloco.translate('register.errorMessage');
         console.error('Error status:', error.status, 'body:', body);
       }
     });


### PR DESCRIPTION
Installs @jsverse/transloco with a custom HTTP loader. Covers header, landing page, registration, and flashcard demo. Language choice is persisted to localStorage and shown in the nav switcher button.