### PR TITLE
Add language selector to flashcard and improve language UX across app

### DIFF
--- a/src/app/flashcard/flashcard.component.css
+++ b/src/app/flashcard/flashcard.component.css
@@ -1,7 +1,6 @@
 .card-flip-container {
   perspective: 1200px;
   height: 220px;
-  margin-bottom: 1.5rem;
 }
 
 .card-inner {
@@ -26,18 +25,8 @@
   height: 100%;
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
-  border-radius: 1rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  padding: 2rem;
-  background: white;
-  box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.08);
 }
 
 .card-face.card-back {
   transform: rotateY(180deg);
-  background: #f8f9fa;
 }

--- a/src/app/flashcard/flashcard.component.html
+++ b/src/app/flashcard/flashcard.component.html
@@ -1,5 +1,37 @@
 <div class="container py-4">
 
+  <!-- Language selector -->
+  @if (languages.length > 0) {
+  <div class="d-flex align-items-center justify-content-center gap-2 mb-4 flex-wrap">
+    <div class="form-check form-switch mb-0 me-1">
+      <input class="form-check-input" type="checkbox" role="switch" id="filterMyLanguages"
+        [(ngModel)]="filterMyLanguages" (change)="onLanguageFilterChange()" />
+      <label class="form-check-label small" for="filterMyLanguages">My languages</label>
+    </div>
+    <span [appTooltip]="filterMyLanguages ? 'Uncheck My languages to edit' : ''">
+      <select class="form-select form-select-sm" style="width: auto" [(ngModel)]="selectedLanguageUuid" (change)="onLanguageChange()" [disabled]="filterMyLanguages">
+        <option value="" disabled>From language</option>
+        @for (lang of languages; track lang.uuid) {
+        <option [value]="lang.uuid" [disabled]="lang.uuid === selectedLanguageToUuid">
+          {{ flags[lang.name] }} {{ lang.name }}
+        </option>
+        }
+      </select>
+    </span>
+    <i class="bi bi-arrow-right text-muted"></i>
+    <span [appTooltip]="filterMyLanguages ? 'Uncheck My languages to edit' : ''">
+      <select class="form-select form-select-sm" style="width: auto" [(ngModel)]="selectedLanguageToUuid" (change)="onLanguageChange()" [disabled]="filterMyLanguages">
+        <option value="" disabled>To language</option>
+        @for (lang of languages; track lang.uuid) {
+        <option [value]="lang.uuid" [disabled]="lang.uuid === selectedLanguageUuid">
+          {{ flags[lang.name] }} {{ lang.name }}
+        </option>
+        }
+      </select>
+    </span>
+  </div>
+  }
+
   <!-- Loading -->
   @if (state === 'loading') {
   <div class="text-center py-5">
@@ -25,9 +57,8 @@
   <div class="row justify-content-center">
     <div class="col-md-6 text-center py-5">
       <i class="bi bi-translate fs-1 text-muted"></i>
-      <h4 class="mt-3">No language settings found</h4>
-      <p class="text-muted">Please configure your languages before starting flashcards.</p>
-      <a routerLink="/settings/languages" class="btn btn-primary mt-2">Configure Languages</a>
+      <h4 class="mt-3">Select your languages</h4>
+      <p class="text-muted">Choose the from and to languages above to start practicing.</p>
     </div>
   </div>
   }
@@ -67,17 +98,17 @@
       </div>
 
       <!-- Card -->
-      <div class="card-flip-container" (click)="state === 'sentence' && reveal()" [style.cursor]="state === 'sentence' ? 'pointer' : 'default'" [title]="state === 'sentence' ? 'Click to reveal the translation' : ''">
+      <div class="card-flip-container mb-4" (click)="state === 'sentence' && reveal()" [style.cursor]="state === 'sentence' ? 'pointer' : 'default'" [title]="state === 'sentence' ? 'Click to reveal the translation' : ''">
         <div class="card-inner" [class.flipped]="isFlipped" [class.no-transition]="skipTransition">
 
           <!-- Front: sentence -->
-          <div class="card-face card-front">
+          <div class="card-face card-front rounded-4 d-flex flex-column justify-content-center align-items-center text-center bg-white shadow-sm" style="padding: 2rem">
             <p class="text-muted small mb-2">Translate this word</p>
             <h2 class="mb-0">{{ currentWord.sentence }}</h2>
           </div>
 
           <!-- Back: translation -->
-          <div class="card-face card-back">
+          <div class="card-face card-back rounded-4 d-flex flex-column justify-content-center align-items-center text-center bg-light shadow-sm" style="padding: 2rem">
             <p class="text-muted small mb-2">Sentence</p>
             <h2 class="mb-3">{{ currentWord.sentence }}</h2>
             <hr class="w-100 my-0">
@@ -91,19 +122,14 @@
       <!-- Hint (first card only) -->
       @if (state === 'sentence' && currentIndex === 0) {
       <p class="text-center text-muted small mb-3">
-        <i class="bi bi-hand-index me-1"></i>Tap the card or click <strong>Reveal</strong> to see the translation
+        <i class="bi bi-hand-index me-1"></i>Tap the card to see the translation
       </p>
       }
 
       <!-- Actions -->
       @if (state === 'sentence') {
       <div class="row g-2">
-        <div class="col-8">
-          <button class="btn btn-outline-primary w-100 btn-lg" (click)="reveal()">
-            <i class="bi bi-eye me-2"></i>Reveal
-          </button>
-        </div>
-        <div class="col-4">
+        <div class="col-12">
           <button class="btn btn-outline-secondary w-100 btn-lg" (click)="submit('SKIP')">
             <i class="bi bi-arrow-right me-1"></i>Skip
           </button>

--- a/src/app/flashcard/flashcard.component.ts
+++ b/src/app/flashcard/flashcard.component.ts
@@ -1,9 +1,15 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
+import { forkJoin } from 'rxjs';
 import { FlashcardService } from '../shared/service/flashcard/flashcard.service';
 import { UserLanguagesService } from '../shared/service/user/user-languages.service';
+import { LanguagesStore } from '../shared/store/language.store';
 import { WordView, WordReviewResultType } from '../shared/model/flashcard.model';
+import { Language } from '../shared/model/language';
+import { LANGUAGE_FLAGS } from '../shared/model/flag';
+import { TooltipDirective } from '../shared/directive/tooltip.directive';
 
 type SessionState = 'loading' | 'no-languages' | 'no-words' | 'error' | 'sentence' | 'translation' | 'complete';
 
@@ -15,13 +21,16 @@ interface ReviewEntry {
 @Component({
   selector: 'app-flashcard',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, RouterLink, FormsModule, TooltipDirective],
   templateUrl: './flashcard.component.html',
   styleUrl: './flashcard.component.css',
 })
 export class FlashcardComponent implements OnInit {
   private readonly flashcardService = inject(FlashcardService);
   private readonly userLanguagesService = inject(UserLanguagesService);
+  private readonly languagesStore = inject(LanguagesStore);
+
+  readonly flags = LANGUAGE_FLAGS;
 
   state: SessionState = 'loading';
   words: WordView[] = [];
@@ -31,6 +40,13 @@ export class FlashcardComponent implements OnInit {
   isFlipped = false;
   skipTransition = false;
 
+  languages: Language[] = [];
+  filterMyLanguages = false;
+  selectedLanguageUuid = '';
+  selectedLanguageToUuid = '';
+
+  private defaultLanguageUuid = '';
+  private defaultLanguageToUuid = '';
   private languageUuid?: string;
   private languageToUuid?: string;
 
@@ -51,14 +67,24 @@ export class FlashcardComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.userLanguagesService.get().subscribe({
-      next: (userLang) => {
-        if (!userLang.language?.uuid || !userLang.languageTo?.uuid) {
+    forkJoin({
+      langs: this.languagesStore.getAll$(),
+      userLang: this.userLanguagesService.get(),
+    }).subscribe({
+      next: ({ langs, userLang }) => {
+        this.languages = langs;
+        this.defaultLanguageUuid = userLang.language?.uuid ?? '';
+        this.defaultLanguageToUuid = userLang.languageTo?.uuid ?? '';
+        this.selectedLanguageUuid = this.defaultLanguageUuid;
+        this.selectedLanguageToUuid = this.defaultLanguageToUuid;
+        this.filterMyLanguages = !!(this.defaultLanguageUuid && this.defaultLanguageToUuid);
+
+        if (!this.selectedLanguageUuid || !this.selectedLanguageToUuid) {
           this.state = 'no-languages';
           return;
         }
-        this.languageUuid = userLang.language.uuid;
-        this.languageToUuid = userLang.languageTo.uuid;
+        this.languageUuid = this.selectedLanguageUuid;
+        this.languageToUuid = this.selectedLanguageToUuid;
         this.loadWords();
       },
       error: () => {
@@ -66,6 +92,28 @@ export class FlashcardComponent implements OnInit {
         this.state = 'error';
       },
     });
+  }
+
+  onLanguageFilterChange(): void {
+    if (!this.filterMyLanguages) return;
+    if (!this.defaultLanguageUuid || !this.defaultLanguageToUuid) {
+      this.filterMyLanguages = false;
+      return;
+    }
+    this.selectedLanguageUuid = this.defaultLanguageUuid;
+    this.selectedLanguageToUuid = this.defaultLanguageToUuid;
+    this.languageUuid = this.defaultLanguageUuid;
+    this.languageToUuid = this.defaultLanguageToUuid;
+    this.loadWords();
+  }
+
+  onLanguageChange(): void {
+    if (!this.selectedLanguageUuid || !this.selectedLanguageToUuid) return;
+    if (this.selectedLanguageUuid === this.selectedLanguageToUuid) return;
+    this.filterMyLanguages = false;
+    this.languageUuid = this.selectedLanguageUuid;
+    this.languageToUuid = this.selectedLanguageToUuid;
+    this.loadWords();
   }
 
   private loadWords(): void {
@@ -109,7 +157,6 @@ export class FlashcardComponent implements OnInit {
         };
 
         if (this.isFlipped) {
-          // Reset flip instantly (no reverse animation), then advance
           this.skipTransition = true;
           this.isFlipped = false;
           setTimeout(() => {

--- a/src/app/settings/settings-user-languages/settings-user-languages.component.html
+++ b/src/app/settings/settings-user-languages/settings-user-languages.component.html
@@ -23,13 +23,14 @@
                 <i class="bi bi-box-arrow-right me-1 text-primary"></i>From Language
               </label>
               <select id="language-select" class="form-select"
-                [disabled]="!editing()"
+                [appTooltip]="'Click to change your default language'"
                 (change)="onFromChange($event)">
                 <option value="">-- Select Language --</option>
                 @for (l of languages(); track l.uuid) {
                   <option
                     [value]="l.uuid"
-                    [selected]="l.uuid === model().language?.uuid">
+                    [selected]="l.uuid === model().language?.uuid"
+                    [disabled]="l.uuid === model().languageTo?.uuid">
                     {{ flags[l.name] }} {{ l.name }}
                   </option>
                 }
@@ -41,19 +42,24 @@
                 <i class="bi bi-box-arrow-in-right me-1 text-success"></i>To Language
               </label>
               <select id="languageTo-select" class="form-select"
-                [disabled]="!editing()"
+                [appTooltip]="'Click to change your default language'"
                 (change)="onToChange($event)">
                 <option value="">-- Select Language --</option>
                 @for (l of languages(); track l.uuid) {
                   <option
                     [value]="l.uuid"
-                    [selected]="l.uuid === model().languageTo?.uuid">
+                    [selected]="l.uuid === model().languageTo?.uuid"
+                    [disabled]="l.uuid === model().language?.uuid">
                     {{ flags[l.name] }} {{ l.name }}
                   </option>
                 }
               </select>
             </div>
           </div>
+
+          <p class="text-muted small mt-3 mb-0">
+            <i class="bi bi-info-circle me-1"></i>Select your languages and click <strong>Save</strong> to update your defaults.
+          </p>
 
           <!-- Current selection preview -->
           @if (model().language && model().languageTo && getLanguageName(model().language) && getLanguageName(model().languageTo)) {
@@ -78,7 +84,9 @@
             }
 
             @if (saved()) {
-              <div class="alert alert-success py-2 mt-2 mb-0" role="alert">
+              <div class="alert alert-success py-2 mt-2 mb-0" role="alert"
+                [style.opacity]="savedFading() ? '0' : '1'"
+                style="transition: opacity 0.7s ease">
                 <i class="bi bi-check-circle-fill me-2"></i>Preferences updated!
               </div>
             }
@@ -92,20 +100,16 @@
         </div>
 
         <!-- Buttons -->
+        @if (dirty()) {
         <div class="card-footer bg-white d-flex gap-2">
-          @if (!editing()) {
-            <button class="btn btn-outline-primary" (click)="enableEdit()">
-              <i class="bi bi-pencil me-1"></i>Edit
-            </button>
-          } @else {
-            <button class="btn btn-primary" (click)="save()">
-              <i class="bi bi-check-lg me-1"></i>Save
-            </button>
-            <button class="btn btn-outline-secondary" (click)="cancel()" [disabled]="saving()">
-              Cancel
-            </button>
-          }
+          <button class="btn btn-primary" (click)="save()" [disabled]="saving()">
+            <i class="bi bi-check-lg me-1"></i>Save
+          </button>
+          <button class="btn btn-outline-secondary" (click)="cancel()" [disabled]="saving()">
+            Cancel
+          </button>
         </div>
+        }
       </div>
 
       <!-- Available languages info -->

--- a/src/app/settings/settings-user-languages/settings-user-languages.component.ts
+++ b/src/app/settings/settings-user-languages/settings-user-languages.component.ts
@@ -5,9 +5,12 @@ import { LanguagesStore } from '../../shared/store/language.store';
 import { Language } from '../../shared/model/language';
 import { LANGUAGE_FLAGS } from '../../shared/model/flag';
 import { forkJoin } from 'rxjs';
+import { TooltipDirective } from '../../shared/directive/tooltip.directive';
 
 @Component({
   selector: 'app-settings-user-languages',
+  standalone: true,
+  imports: [TooltipDirective],
   templateUrl: './settings-user-languages.component.html',
 })
 export class SettingsUserLanguagesComponent implements OnInit {
@@ -17,8 +20,9 @@ export class SettingsUserLanguagesComponent implements OnInit {
   loading = signal(true);
   saving = signal(false);
   saved = signal(false);
+  savedFading = signal(false);
+  dirty = signal(false);
   error = signal<string | null>(null);
-  editing = signal(false);
 
   languages = signal<Language[]>([]);
 
@@ -32,42 +36,37 @@ export class SettingsUserLanguagesComponent implements OnInit {
   }
 
   private load(): void {
+    this.loading.set(true);
+    this.saved.set(false);
+    this.dirty.set(false);
     forkJoin({
       langs: this.languagesStore.getAll$(),
       userLang: this.userLanguagesService.get(),
     }).subscribe({
       next: ({ langs, userLang }) => {
         this.languages.set(langs);
-        const langFrom =
-          langs.find((l) => l.uuid === userLang.language?.uuid) ?? null;
-        const langTo =
-          langs.find((l) => l.uuid === userLang.languageTo?.uuid) ?? null;
-        this.model.set({
-          ...userLang,
-          language: langFrom,
-          languageTo: langTo,
-        });
+        const langFrom = langs.find((l) => l.uuid === userLang.language?.uuid) ?? null;
+        const langTo = langs.find((l) => l.uuid === userLang.languageTo?.uuid) ?? null;
+        this.model.set({ ...userLang, language: langFrom, languageTo: langTo });
+        this.loading.set(false);
       },
-      error: (err) => {
-        console.error('Error loading word for edit', err);
+      error: () => {
+        this.error.set('Could not load language settings.');
+        this.loading.set(false);
       },
     });
   }
 
   onToChange(event: Event) {
     const uuid = (event.target as HTMLSelectElement).value;
-    this.model.update((m) => ({
-      ...m,
-      languageTo: { uuid },
-    }));
+    this.model.update((m) => ({ ...m, languageTo: { uuid } }));
+    this.dirty.set(true);
   }
 
   onFromChange(event: Event) {
     const uuid = (event.target as HTMLSelectElement).value;
-    this.model.update((m) => ({
-      ...m,
-      language: { uuid },
-    }));
+    this.model.update((m) => ({ ...m, language: { uuid } }));
+    this.dirty.set(true);
   }
 
   getLanguageName(ref: { uuid: string } | null): string {
@@ -76,21 +75,26 @@ export class SettingsUserLanguagesComponent implements OnInit {
     return lang ? lang.name : '';
   }
 
-  enableEdit(): void {
-    this.editing.set(true);
-  }
-
   cancel(): void {
-    this.editing.set(false);
+    this.load();
   }
 
   save(): void {
+    this.saving.set(true);
+    this.saved.set(false);
     this.userLanguagesService.createOrUpdate(this.model()).subscribe({
       next: (updated) => {
         this.model.set(updated);
-        this.editing.set(false); // back to read-only
+        this.saving.set(false);
+        this.saved.set(true);
+        this.dirty.set(false);
+        setTimeout(() => this.savedFading.set(true), 2000);
+        setTimeout(() => { this.saved.set(false); this.savedFading.set(false); }, 2700);
       },
-      complete: () => this.saving.set(false),
+      error: () => {
+        this.error.set('Could not save. Please try again.');
+        this.saving.set(false);
+      },
     });
   }
 }

--- a/src/app/shared/directive/tooltip.directive.ts
+++ b/src/app/shared/directive/tooltip.directive.ts
@@ -1,0 +1,29 @@
+import { Directive, ElementRef, Input, OnChanges, OnDestroy } from '@angular/core';
+
+@Directive({
+  selector: '[appTooltip]',
+  standalone: true,
+})
+export class TooltipDirective implements OnChanges, OnDestroy {
+  @Input('appTooltip') text = '';
+
+  private instance: any;
+
+  constructor(private el: ElementRef<HTMLElement>) {}
+
+  ngOnChanges(): void {
+    this.instance?.dispose();
+    this.instance = undefined;
+    if (this.text) {
+      this.instance = new (window as any).bootstrap.Tooltip(this.el.nativeElement, {
+        title: this.text,
+        trigger: 'hover',
+        placement: 'top',
+      });
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.instance?.dispose();
+  }
+}

--- a/src/app/word/word-list/word-list.component.html
+++ b/src/app/word/word-list/word-list.component.html
@@ -120,24 +120,27 @@
       <div class="w-100 d-sm-none"></div>
 
       
-      <select class="form-select form-select-sm" style="width: auto" [(ngModel)]="filterFromUuid"
-        (change)="onLanguageDropdownChange()">
-        <option value="">Any</option>
-        @for (l of availableLanguages; track l.uuid) {
-        <option [value]="l.uuid">{{ flags[l.name] }} {{ l.name }}</option>
-        }
-      </select>
+      <span [appTooltip]="filterMyLanguages ? 'Uncheck My languages to edit' : ''">
+        <select class="form-select form-select-sm" style="width: auto" [(ngModel)]="filterFromUuid"
+          (change)="onLanguageDropdownChange()" [disabled]="filterMyLanguages">
+          <option value="">Any</option>
+          @for (l of availableLanguages; track l.uuid) {
+          <option [value]="l.uuid">{{ flags[l.name] }} {{ l.name }}</option>
+          }
+        </select>
+      </span>
 
       <i class="bi bi-arrow-right text-muted"></i>
 
-      
-      <select class="form-select form-select-sm" style="width: auto" [(ngModel)]="filterToUuid"
-        (change)="onLanguageDropdownChange()">
-        <option value="">Any</option>
-        @for (l of availableLanguages; track l.uuid) {
-        <option [value]="l.uuid">{{ flags[l.name] }} {{ l.name }}</option>
-        }
-      </select>
+      <span [appTooltip]="filterMyLanguages ? 'Uncheck My languages to edit' : ''">
+        <select class="form-select form-select-sm" style="width: auto" [(ngModel)]="filterToUuid"
+          (change)="onLanguageDropdownChange()" [disabled]="filterMyLanguages">
+          <option value="">Any</option>
+          @for (l of availableLanguages; track l.uuid) {
+          <option [value]="l.uuid">{{ flags[l.name] }} {{ l.name }}</option>
+          }
+        </select>
+      </span>
 
       
       @if (filterFromUuid || filterToUuid) {

--- a/src/app/word/word-list/word-list.component.ts
+++ b/src/app/word/word-list/word-list.component.ts
@@ -8,12 +8,13 @@ import { Word } from '../../shared/model/word.model';
 import { Language } from '../../shared/model/language';
 import { RouterLink } from '@angular/router';
 import { LANGUAGE_FLAGS } from '../../shared/model/flag';
+import { TooltipDirective } from '../../shared/directive/tooltip.directive';
 import { Subject, forkJoin } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-word-list',
-  imports: [CommonModule, RouterLink, ReactiveFormsModule, FormsModule],
+  imports: [CommonModule, RouterLink, ReactiveFormsModule, FormsModule, TooltipDirective],
   templateUrl: './word-list.component.html',
   styleUrl: './word-list.component.css',
 })
@@ -123,9 +124,6 @@ export class WordListComponent implements OnInit, OnDestroy {
   public onLanguageFilterChange(): void {
     this.noLanguageSettings = false;
     if (!this.filterMyLanguages) {
-      this.filterFromUuid = '';
-      this.filterToUuid = '';
-      this.reload(0);
       return;
     }
 


### PR DESCRIPTION
- Flashcard: inline from/to language selector with session-only switching and My languages toggle
- Word list: sync My languages toggle behaviour (keep selection on uncheck, disable dropdowns when locked)
- Settings languages: remove edit toggle, always-editable dropdowns, dirty-aware Save/Cancel, fade-out success message
- Shared: add reusable Bootstrap TooltipDirective (uses window.bootstrap)