### PR TITLE
Add public German practice page — articles and plural exercises (#109)

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -48,6 +48,11 @@
       "title": "Bereit, deinen Wortschatz zu erweitern?",
       "subtitle": "Kostenlos registrieren und noch heute loslegen.",
       "createAccount": "Konto erstellen"
+    },
+    "deutsch": {
+      "title": "Deutsch kostenlos üben",
+      "subtitle": "Deutsche Nomen üben — Artikel und Pluralformen. Kein Konto nötig.",
+      "cta": "Deutsch üben"
     }
   },
   "demo": {
@@ -72,6 +77,36 @@
     "ctaTitle": "Mit deinem eigenen Wortschatz üben",
     "ctaSubtitle": "Erstelle ein kostenloses Konto, um eigene Wörter hinzuzufügen und deinen Fortschritt zu verfolgen.",
     "createFreeAccountBtn": "Kostenloses Konto erstellen",
+    "alreadyHaveAccount": "Hast du bereits ein Konto?",
+    "logIn": "Anmelden"
+  },
+  "learnDeutsch": {
+    "title": "Deutsch üben",
+    "subtitle": "Deutsch üben — kein Konto erforderlich.",
+    "articles": "Artikel",
+    "articlesHint": "der / die / das",
+    "plural": "Plural",
+    "pluralHint": "richtigen Plural wählen",
+    "startPractice": "Übung starten",
+    "wantOwnWords": "Möchtest du deinen eigenen Wortschatz üben?",
+    "createFreeAccount": "Kostenloses Konto erstellen",
+    "loading": "Übungen werden geladen…",
+    "errorTitle": "Übungen konnten nicht geladen werden",
+    "errorMessage": "Bitte überprüfe deine Verbindung und versuche es erneut.",
+    "retry": "Erneut versuchen",
+    "changeMode": "Modus wechseln",
+    "cardProgress": "Karte {{ current }} von {{ total }}",
+    "whatArticle": "Was ist der Artikel?",
+    "whatPlural": "Was ist der Plural?",
+    "correct": "Richtig!",
+    "wrong": "Falsch!",
+    "next": "Weiter",
+    "sessionComplete": "Sitzung abgeschlossen!",
+    "reviewed": "Du hast {{ total }} Fragen beantwortet",
+    "practiceAgain": "Nochmal üben",
+    "ctaTitle": "Mit deinem eigenen Wortschatz üben",
+    "ctaSubtitle": "Erstelle ein kostenloses Konto, um eigene Wörter hinzuzufügen und Fortschritte zu verfolgen.",
+    "createAccountBtn": "Kostenloses Konto erstellen",
     "alreadyHaveAccount": "Hast du bereits ein Konto?",
     "logIn": "Anmelden"
   },

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -48,6 +48,11 @@
       "title": "Ready to expand your vocabulary?",
       "subtitle": "Join for free and start learning today.",
       "createAccount": "Create Account"
+    },
+    "deutsch": {
+      "title": "Practice German for free",
+      "subtitle": "Practice German nouns — articles and plural forms. No account needed.",
+      "cta": "Try German Practice"
     }
   },
   "demo": {
@@ -72,6 +77,36 @@
     "ctaTitle": "Practice your own vocabulary",
     "ctaSubtitle": "Create a free account to add your own words and track your progress across sessions.",
     "createFreeAccountBtn": "Create Free Account",
+    "alreadyHaveAccount": "Already have an account?",
+    "logIn": "Log in"
+  },
+  "learnDeutsch": {
+    "title": "German Practice",
+    "subtitle": "Practice German — no account needed.",
+    "articles": "Articles",
+    "articlesHint": "der / die / das",
+    "plural": "Plural",
+    "pluralHint": "choose the correct plural",
+    "startPractice": "Start Practice",
+    "wantOwnWords": "Want to practice your own vocabulary?",
+    "createFreeAccount": "Create a free account",
+    "loading": "Loading exercises…",
+    "errorTitle": "Could not load exercises",
+    "errorMessage": "Please check your connection and try again.",
+    "retry": "Retry",
+    "changeMode": "Change mode",
+    "cardProgress": "Card {{ current }} of {{ total }}",
+    "whatArticle": "What is the article?",
+    "whatPlural": "What is the plural?",
+    "correct": "Correct!",
+    "wrong": "Wrong!",
+    "next": "Next",
+    "sessionComplete": "Session complete!",
+    "reviewed": "You answered {{ total }} questions",
+    "practiceAgain": "Practice Again",
+    "ctaTitle": "Practice your own vocabulary",
+    "ctaSubtitle": "Create a free account to add your own words and track progress across sessions.",
+    "createAccountBtn": "Create Free Account",
     "alreadyHaveAccount": "Already have an account?",
     "logIn": "Log in"
   },

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -48,6 +48,11 @@
       "title": "¿Listo para ampliar tu vocabulario?",
       "subtitle": "Regístrate gratis y empieza a aprender hoy.",
       "createAccount": "Crear cuenta"
+    },
+    "deutsch": {
+      "title": "Practica alemán gratis",
+      "subtitle": "Practica sustantivos alemanes — artículos y plurales. Sin cuenta.",
+      "cta": "Practicar alemán"
     }
   },
   "demo": {
@@ -72,6 +77,36 @@
     "ctaTitle": "Practica con tu propio vocabulario",
     "ctaSubtitle": "Crea una cuenta gratuita para añadir tus propias palabras y seguir tu progreso entre sesiones.",
     "createFreeAccountBtn": "Crear cuenta gratuita",
+    "alreadyHaveAccount": "¿Ya tienes una cuenta?",
+    "logIn": "Iniciar sesión"
+  },
+  "learnDeutsch": {
+    "title": "Práctica de alemán",
+    "subtitle": "Practica alemán — sin cuenta.",
+    "articles": "Artículos",
+    "articlesHint": "der / die / das",
+    "plural": "Plural",
+    "pluralHint": "elige el plural correcto",
+    "startPractice": "Comenzar práctica",
+    "wantOwnWords": "¿Quieres practicar tu propio vocabulario?",
+    "createFreeAccount": "Crear una cuenta gratuita",
+    "loading": "Cargando ejercicios…",
+    "errorTitle": "No se pudieron cargar los ejercicios",
+    "errorMessage": "Comprueba tu conexión e inténtalo de nuevo.",
+    "retry": "Reintentar",
+    "changeMode": "Cambiar modo",
+    "cardProgress": "Tarjeta {{ current }} de {{ total }}",
+    "whatArticle": "¿Cuál es el artículo?",
+    "whatPlural": "¿Cuál es el plural?",
+    "correct": "¡Correcto!",
+    "wrong": "¡Incorrecto!",
+    "next": "Siguiente",
+    "sessionComplete": "¡Sesión completada!",
+    "reviewed": "Respondiste {{ total }} preguntas",
+    "practiceAgain": "Practicar de nuevo",
+    "ctaTitle": "Practica con tu propio vocabulario",
+    "ctaSubtitle": "Crea una cuenta gratuita para añadir tus palabras y seguir tu progreso.",
+    "createAccountBtn": "Crear cuenta gratuita",
     "alreadyHaveAccount": "¿Ya tienes una cuenta?",
     "logIn": "Iniciar sesión"
   },

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -48,6 +48,11 @@
       "title": "Pronto ad arricchire il tuo vocabolario?",
       "subtitle": "Registrati gratis e inizia ad imparare oggi.",
       "createAccount": "Crea account"
+    },
+    "deutsch": {
+      "title": "Pratica il tedesco gratis",
+      "subtitle": "Pratica i sostantivi tedeschi — articoli e plurali. Senza account.",
+      "cta": "Prova la pratica tedesco"
     }
   },
   "demo": {
@@ -72,6 +77,36 @@
     "ctaTitle": "Pratica con il tuo vocabolario",
     "ctaSubtitle": "Crea un account gratuito per aggiungere le tue parole e seguire i progressi tra le sessioni.",
     "createFreeAccountBtn": "Crea account gratuito",
+    "alreadyHaveAccount": "Hai già un account?",
+    "logIn": "Accedi"
+  },
+  "learnDeutsch": {
+    "title": "Pratica il tedesco",
+    "subtitle": "Pratica il tedesco — senza account.",
+    "articles": "Articoli",
+    "articlesHint": "der / die / das",
+    "plural": "Plurale",
+    "pluralHint": "scegli il plurale corretto",
+    "startPractice": "Inizia la pratica",
+    "wantOwnWords": "Vuoi praticare con il tuo vocabolario?",
+    "createFreeAccount": "Crea un account gratuito",
+    "loading": "Caricamento esercizi…",
+    "errorTitle": "Impossibile caricare gli esercizi",
+    "errorMessage": "Controlla la connessione e riprova.",
+    "retry": "Riprova",
+    "changeMode": "Cambia modalità",
+    "cardProgress": "Scheda {{ current }} di {{ total }}",
+    "whatArticle": "Qual è l'articolo?",
+    "whatPlural": "Qual è il plurale?",
+    "correct": "Corretto!",
+    "wrong": "Sbagliato!",
+    "next": "Avanti",
+    "sessionComplete": "Sessione completata!",
+    "reviewed": "Hai risposto a {{ total }} domande",
+    "practiceAgain": "Pratica di nuovo",
+    "ctaTitle": "Pratica con il tuo vocabolario",
+    "ctaSubtitle": "Crea un account gratuito per aggiungere le tue parole e seguire i progressi.",
+    "createAccountBtn": "Crea account gratuito",
     "alreadyHaveAccount": "Hai già un account?",
     "logIn": "Accedi"
   },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -18,6 +18,7 @@ import { TermsComponent } from './legal/terms/terms.component';
 import { CookiesComponent } from './legal/cookies/cookies.component';
 import { AboutComponent } from './about/about.component';
 import { DemoFlashcardComponent } from './demo-flashcard/demo-flashcard.component';
+import { LearnDeutschComponent } from './learn-deutsch/learn-deutsch.component';
 
 export const routes: Routes = [
   {
@@ -82,6 +83,11 @@ export const routes: Routes = [
   {
     path: 'demo',
     component: DemoFlashcardComponent,
+  },
+
+  {
+    path: 'learn-deutsch',
+    component: LearnDeutschComponent,
   },
 
   {

--- a/src/app/landing/landing.component.html
+++ b/src/app/landing/landing.component.html
@@ -1,5 +1,26 @@
 <app-disclaimer></app-disclaimer>
 
+<!-- German Practice Banner -->
+<section class="py-3 py-md-4">
+  <div class="container">
+    <div class="card border-0 shadow-sm" style="background: linear-gradient(135deg, #FFCC00 0%, #FFD700 100%);">
+      <div class="card-body py-3 py-md-4 px-3 px-md-4">
+        <div class="row align-items-center g-3">
+          <div class="col-12 col-md-8">
+            <h5 class="fw-bold mb-1">{{ 'landing.deutsch.title' | transloco }}</h5>
+            <p class="mb-0 small">{{ 'landing.deutsch.subtitle' | transloco }}</p>
+          </div>
+          <div class="col-12 col-md-4 text-md-end">
+            <a routerLink="/learn-deutsch" class="btn btn-dark fw-semibold">
+              <i class="bi bi-play-fill me-1"></i>{{ 'landing.deutsch.cta' | transloco }}
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- Hero -->
 <section class="py-3 py-lg-5 bg-primary bg-gradient text-white">
   <div class="container">

--- a/src/app/learn-deutsch/learn-deutsch.component.html
+++ b/src/app/learn-deutsch/learn-deutsch.component.html
@@ -1,0 +1,212 @@
+<div class="container py-4">
+
+  <!-- Idle: mode picker -->
+  @if (state === 'idle') {
+  <div class="row justify-content-center">
+    <div class="col-md-5 text-center py-4">
+      <div class="fs-1">🇩🇪</div>
+      <h3 class="mt-3 fw-bold">{{ 'learnDeutsch.title' | transloco }}</h3>
+      <p class="text-muted mb-4">{{ 'learnDeutsch.subtitle' | transloco }}</p>
+
+      <div class="row g-3 mb-4">
+        <div class="col-6">
+          <div class="card h-100 border-2"
+               [class.border-primary]="mode === 'articles'"
+               [class.border-light]="mode !== 'articles'"
+               style="cursor: pointer;"
+               (click)="selectMode('articles')">
+            <div class="card-body text-center py-3">
+              <i class="bi bi-journal-text fs-2 text-primary"></i>
+              <h6 class="fw-bold mb-1 mt-2">{{ 'learnDeutsch.articles' | transloco }}</h6>
+              <small class="text-muted">{{ 'learnDeutsch.articlesHint' | transloco }}</small>
+            </div>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="card h-100 border-2"
+               [class.border-primary]="mode === 'plural'"
+               [class.border-light]="mode !== 'plural'"
+               style="cursor: pointer;"
+               (click)="selectMode('plural')">
+            <div class="card-body text-center py-3">
+              <i class="bi bi-lightning-charge fs-2 text-success"></i>
+              <h6 class="fw-bold mb-1 mt-2">{{ 'learnDeutsch.plural' | transloco }}</h6>
+              <small class="text-muted">{{ 'learnDeutsch.pluralHint' | transloco }}</small>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <button class="btn btn-primary btn-lg w-100" (click)="start()">
+        <i class="bi bi-play-fill me-2"></i>{{ 'learnDeutsch.startPractice' | transloco }}
+      </button>
+
+      <p class="mt-4 mb-0 small text-muted">
+        {{ 'learnDeutsch.wantOwnWords' | transloco }}
+        <a routerLink="/register" class="fw-semibold">{{ 'learnDeutsch.createFreeAccount' | transloco }}</a>
+      </p>
+    </div>
+  </div>
+  }
+
+  <!-- Loading -->
+  @if (state === 'loading') {
+  <div class="text-center py-5">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Loading…</span>
+    </div>
+    <p class="mt-3 text-muted">{{ 'learnDeutsch.loading' | transloco }}</p>
+  </div>
+  }
+
+  <!-- Error -->
+  @if (state === 'error') {
+  <div class="row justify-content-center">
+    <div class="col-md-5 text-center py-5">
+      <i class="bi bi-exclamation-triangle-fill fs-1 text-danger"></i>
+      <h5 class="mt-3">{{ 'learnDeutsch.errorTitle' | transloco }}</h5>
+      <p class="text-muted">{{ 'learnDeutsch.errorMessage' | transloco }}</p>
+      <button class="btn btn-outline-primary" (click)="start()">
+        <i class="bi bi-arrow-clockwise me-1"></i>{{ 'learnDeutsch.retry' | transloco }}
+      </button>
+    </div>
+  </div>
+  }
+
+  <!-- Practicing -->
+  @if (state === 'practicing') {
+  <div class="row justify-content-center">
+    <div class="col-md-7 col-lg-6">
+
+      <!-- Header -->
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <span class="fs-3">🇩🇪</span>
+        <button class="btn btn-sm btn-outline-secondary" (click)="backToMenu()">
+          {{ 'learnDeutsch.changeMode' | transloco }}
+        </button>
+      </div>
+
+      <!-- Progress -->
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <span class="text-muted small">
+          {{ 'learnDeutsch.cardProgress' | transloco: { current: currentIndex + 1, total: items.length } }}
+        </span>
+        <div class="d-flex gap-3 small">
+          <span class="text-success"><i class="bi bi-check-circle-fill"></i> {{ correctCount }}</span>
+          <span class="text-danger"><i class="bi bi-x-circle-fill"></i> {{ wrongCount }}</span>
+        </div>
+      </div>
+
+      <div class="progress mb-4" style="height: 6px;">
+        <div class="progress-bar" [style.width.%]="(currentIndex / items.length) * 100"></div>
+      </div>
+
+      <!-- Word card -->
+      <div class="card border-0 shadow-sm mb-3">
+        <div class="card-body text-center py-4">
+          <p class="text-muted small mb-2">
+            @if (mode === 'articles') {
+              {{ 'learnDeutsch.whatArticle' | transloco }}
+            } @else {
+              {{ 'learnDeutsch.whatPlural' | transloco }}
+            }
+          </p>
+          <h2 class="fw-bold mb-0">{{ current.word }}</h2>
+
+          @if (isAnswered) {
+            <div class="mt-3">
+              <span class="badge bg-light text-dark border fs-6">{{ current.hint }}</span>
+            </div>
+          }
+        </div>
+      </div>
+
+      <!-- Options -->
+      <div class="row g-2">
+        @for (option of current.options; track option) {
+          <div [class]="optionColClass">
+            <button class="btn w-100 btn-lg"
+                    [ngClass]="getButtonNgClass(option)"
+                    [disabled]="isAnswered"
+                    (click)="answer(option)">
+              {{ option }}
+            </button>
+          </div>
+        }
+      </div>
+
+      <!-- Feedback + timer + Next -->
+      @if (isAnswered) {
+        <div class="progress mt-3" style="height: 4px;">
+          <div class="progress-bar bg-secondary" [style.width.%]="timerProgress"></div>
+        </div>
+        <div class="d-flex align-items-center justify-content-between mt-2">
+          @if (isCorrect) {
+            <span class="badge bg-success px-3 py-2 fs-6">
+              <i class="bi bi-check-circle-fill me-1"></i>{{ 'learnDeutsch.correct' | transloco }}
+            </span>
+          } @else {
+            <span class="badge bg-danger px-3 py-2 fs-6">
+              <i class="bi bi-x-circle-fill me-1"></i>{{ 'learnDeutsch.wrong' | transloco }}
+              — {{ current.correctAnswer }}
+            </span>
+          }
+          <button class="btn btn-primary" (click)="next()">
+            {{ 'learnDeutsch.next' | transloco }} <i class="bi bi-arrow-right ms-1"></i>
+          </button>
+        </div>
+      }
+
+    </div>
+  </div>
+  }
+
+  <!-- Complete -->
+  @if (state === 'complete') {
+  <div class="row justify-content-center">
+    <div class="col-md-6 text-center py-4">
+      <i class="bi bi-trophy-fill fs-1 text-warning"></i>
+      <h3 class="mt-3">{{ 'learnDeutsch.sessionComplete' | transloco }}</h3>
+      <p class="text-muted">{{ 'learnDeutsch.reviewed' | transloco: { total: items.length } }}</p>
+
+      <div class="row g-3 my-3">
+        <div class="col-6">
+          <div class="card border-0 bg-success bg-opacity-10 py-3">
+            <div class="fs-2 fw-bold text-success">{{ correctCount }}</div>
+            <div class="small text-muted">{{ 'learnDeutsch.correct' | transloco }}</div>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="card border-0 bg-danger bg-opacity-10 py-3">
+            <div class="fs-2 fw-bold text-danger">{{ wrongCount }}</div>
+            <div class="small text-muted">{{ 'learnDeutsch.wrong' | transloco }}</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="d-flex gap-2 justify-content-center mt-3">
+        <button class="btn btn-outline-primary" (click)="restart()">
+          <i class="bi bi-arrow-clockwise me-2"></i>{{ 'learnDeutsch.practiceAgain' | transloco }}
+        </button>
+        <button class="btn btn-outline-secondary" (click)="backToMenu()">
+          {{ 'learnDeutsch.changeMode' | transloco }}
+        </button>
+      </div>
+
+      <div class="card border-0 bg-primary bg-opacity-10 mt-4 p-4">
+        <h5 class="fw-bold mb-2">{{ 'learnDeutsch.ctaTitle' | transloco }}</h5>
+        <p class="text-muted small mb-3">{{ 'learnDeutsch.ctaSubtitle' | transloco }}</p>
+        <a routerLink="/register" class="btn btn-primary">
+          <i class="bi bi-person-plus me-2"></i>{{ 'learnDeutsch.createAccountBtn' | transloco }}
+        </a>
+        <p class="mt-2 mb-0 small text-muted">
+          {{ 'learnDeutsch.alreadyHaveAccount' | transloco }}
+          <a routerLink="/">{{ 'learnDeutsch.logIn' | transloco }}</a>
+        </p>
+      </div>
+
+    </div>
+  </div>
+  }
+
+</div>

--- a/src/app/learn-deutsch/learn-deutsch.component.ts
+++ b/src/app/learn-deutsch/learn-deutsch.component.ts
@@ -1,0 +1,176 @@
+import { Component, inject, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+import { LearnDeutschService } from './learn-deutsch.service';
+import { DeutschNoun, PracticeItem } from './learn-deutsch.model';
+
+type PageState = 'idle' | 'loading' | 'error' | 'practicing' | 'complete';
+type Mode = 'articles' | 'plural';
+
+const TIMER_MS = 3000;
+const TIMER_STEP_MS = 50;
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+@Component({
+  selector: 'app-learn-deutsch',
+  standalone: true,
+  imports: [CommonModule, RouterLink, TranslocoModule],
+  templateUrl: './learn-deutsch.component.html',
+})
+export class LearnDeutschComponent implements OnDestroy {
+  private readonly svc = inject(LearnDeutschService);
+
+  readonly articleOptions = ['der', 'die', 'das'];
+  readonly SESSION_SIZE = 20;
+
+  state: PageState = 'idle';
+  mode: Mode = 'articles';
+
+  items: PracticeItem[] = [];
+  currentIndex = 0;
+  selected: string | null = null;
+  isAnswered = false;
+  correctCount = 0;
+  wrongCount = 0;
+  timerProgress = 100;
+
+  private timerInterval: ReturnType<typeof setInterval> | null = null;
+
+  get current(): PracticeItem {
+    return this.items[this.currentIndex];
+  }
+
+  get isCorrect(): boolean {
+    return this.selected === this.current.correctAnswer;
+  }
+
+  get optionColClass(): string {
+    return this.mode === 'articles' ? 'col-4' : 'col-6';
+  }
+
+  ngOnDestroy(): void {
+    this.clearTimer();
+  }
+
+  selectMode(m: Mode): void {
+    this.mode = m;
+  }
+
+  start(): void {
+    this.clearTimer();
+    this.state = 'loading';
+    this.svc.getNouns().subscribe({
+      next: (data) => {
+        const items = this.mode === 'articles'
+          ? this.buildArticleItems(data)
+          : this.buildPluralItems(data);
+        this.initSession(items);
+      },
+      error: () => { this.state = 'error'; },
+    });
+  }
+
+  answer(option: string): void {
+    if (this.isAnswered) return;
+    this.selected = option;
+    this.isAnswered = true;
+    if (option === this.current.correctAnswer) {
+      this.correctCount++;
+    } else {
+      this.wrongCount++;
+    }
+    this.startTimer();
+  }
+
+  next(): void {
+    this.clearTimer();
+    this.advance();
+  }
+
+  restart(): void {
+    this.start();
+  }
+
+  backToMenu(): void {
+    this.clearTimer();
+    this.state = 'idle';
+  }
+
+  getButtonNgClass(option: string): Record<string, boolean> {
+    const isCorrectOption = option === this.current.correctAnswer;
+    const isSelectedOption = option === this.selected;
+    return {
+      'btn-outline-dark': !this.isAnswered,
+      'btn-success': this.isAnswered && isCorrectOption,
+      'btn-danger': this.isAnswered && isSelectedOption && !isCorrectOption,
+      'btn-outline-secondary': this.isAnswered && !isCorrectOption && !isSelectedOption,
+    };
+  }
+
+  private startTimer(): void {
+    this.timerProgress = 100;
+    const decrement = (100 / TIMER_MS) * TIMER_STEP_MS;
+    this.timerInterval = setInterval(() => {
+      this.timerProgress = Math.max(0, this.timerProgress - decrement);
+      if (this.timerProgress === 0) {
+        this.clearTimer();
+        this.advance();
+      }
+    }, TIMER_STEP_MS);
+  }
+
+  private clearTimer(): void {
+    if (this.timerInterval !== null) {
+      clearInterval(this.timerInterval);
+      this.timerInterval = null;
+    }
+    this.timerProgress = 100;
+  }
+
+  private initSession(items: PracticeItem[]): void {
+    this.items = items;
+    this.currentIndex = 0;
+    this.selected = null;
+    this.isAnswered = false;
+    this.correctCount = 0;
+    this.wrongCount = 0;
+    this.state = 'practicing';
+  }
+
+  private buildArticleItems(nouns: DeutschNoun[]): PracticeItem[] {
+    return shuffle(nouns).slice(0, this.SESSION_SIZE).map(n => ({
+      word: n.wordDe,
+      correctAnswer: n.article,
+      hint: `${n.article} ${n.wordDe}`,
+      options: this.articleOptions,
+    }));
+  }
+
+  private buildPluralItems(nouns: DeutschNoun[]): PracticeItem[] {
+    return shuffle(nouns).slice(0, this.SESSION_SIZE).map(n => ({
+      word: n.wordDe,
+      correctAnswer: n.pluralDe,
+      hint: n.pluralDe,
+      options: shuffle([n.pluralDe, ...n.pluralDistractors.slice(0, 3)]),
+    }));
+  }
+
+  private advance(): void {
+    if (this.currentIndex + 1 >= this.items.length) {
+      this.state = 'complete';
+    } else {
+      this.currentIndex++;
+      this.selected = null;
+      this.isAnswered = false;
+    }
+  }
+}

--- a/src/app/learn-deutsch/learn-deutsch.model.ts
+++ b/src/app/learn-deutsch/learn-deutsch.model.ts
@@ -1,0 +1,14 @@
+export interface DeutschNoun {
+  uuid: string;
+  wordDe: string;
+  article: string;
+  pluralDe: string;
+  pluralDistractors: string[];
+}
+
+export interface PracticeItem {
+  word: string;
+  correctAnswer: string;
+  hint: string;
+  options: string[];
+}

--- a/src/app/learn-deutsch/learn-deutsch.service.ts
+++ b/src/app/learn-deutsch/learn-deutsch.service.ts
@@ -1,0 +1,16 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { DeutschNoun } from './learn-deutsch.model';
+import { environment as env } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class LearnDeutschService {
+  private readonly baseUrl = `${env.apiBaseUrl}/public`;
+  private readonly http = inject(HttpClient);
+
+  getNouns(limit = 100): Observable<DeutschNoun[]> {
+    const params = new HttpParams().set('limit', limit);
+    return this.http.get<DeutschNoun[]>(`${this.baseUrl}/nouns/de-it`, { params });
+  }
+}


### PR DESCRIPTION
- New feature module src/app/learn-deutsch with model, service and component
- Public route /learn-deutsch (no auth guard)
- Two exercise modes: article quiz (der/die/das) and plural quiz using API pluralDistractors
- Multiple-choice with instant feedback, 3-second countdown timer + Next button
- German practice banner added to landing page (first section after disclaimer)
- i18n keys for EN, IT, DE, ES