### PR TITLE
Adapt UI to new backend API and add admin section for noun example ge…

### DIFF
--- a/src/app/admin/admin-layout.component.html
+++ b/src/app/admin/admin-layout.component.html
@@ -1,0 +1,30 @@
+<div class="container-fluid py-4">
+  <div class="row">
+
+    <!-- Sidebar -->
+    <div class="col-md-3 col-lg-2 mb-4 mb-md-0">
+      <div class="card border-0 shadow-sm">
+        <div class="card-header bg-dark text-white py-3">
+          <div class="d-flex align-items-center gap-2">
+            <i class="bi bi-shield-lock-fill"></i>
+            <span class="fw-semibold">Admin</span>
+          </div>
+        </div>
+        <div class="list-group list-group-flush">
+          <a routerLink="/admin/noun-examples"
+             routerLinkActive="active bg-primary text-white"
+             class="list-group-item list-group-item-action d-flex align-items-center gap-2 py-3">
+            <i class="bi bi-magic"></i>
+            <span>Noun Examples</span>
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Main content -->
+    <div class="col-md-9 col-lg-10">
+      <router-outlet></router-outlet>
+    </div>
+
+  </div>
+</div>

--- a/src/app/admin/admin-layout.component.ts
+++ b/src/app/admin/admin-layout.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-admin-layout',
+  standalone: true,
+  imports: [RouterModule],
+  templateUrl: './admin-layout.component.html',
+})
+export class AdminLayoutComponent {}

--- a/src/app/admin/noun-examples-admin.service.ts
+++ b/src/app/admin/noun-examples-admin.service.ts
@@ -1,0 +1,18 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as env } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class NounExamplesAdminService {
+  private readonly baseUrl = `${env.apiBaseUrl}/admin`;
+  private readonly http = inject(HttpClient);
+
+  generateExamples(lang: string, limit?: number): Observable<void> {
+    let params = new HttpParams().set('lang', lang);
+    if (limit != null) {
+      params = params.set('limit', limit);
+    }
+    return this.http.post<void>(`${this.baseUrl}/nouns/de/examples/generate`, null, { params });
+  }
+}

--- a/src/app/admin/noun-examples/noun-examples-admin.component.html
+++ b/src/app/admin/noun-examples/noun-examples-admin.component.html
@@ -1,0 +1,50 @@
+<h4 class="fw-bold mb-1">Generate DE Noun Examples</h4>
+<p class="text-muted mb-4">Triggers async Claude generation for nouns missing example sentences.</p>
+
+<div class="card border-0 shadow-sm" style="max-width: 480px;">
+  <div class="card-body p-4">
+
+    <div class="mb-3">
+      <label class="form-label fw-semibold">Translation language</label>
+      <select class="form-select" [(ngModel)]="selectedLang">
+        @for (lang of langs; track lang.code) {
+          <option [value]="lang.code">{{ lang.label }}</option>
+        }
+      </select>
+    </div>
+
+    <div class="mb-4">
+      <label class="form-label fw-semibold">
+        Limit <span class="text-muted fw-normal">(optional — leave empty for all)</span>
+      </label>
+      <input type="number" class="form-control" min="1"
+             [(ngModel)]="limit" placeholder="e.g. 10">
+    </div>
+
+    <button class="btn btn-primary w-100"
+            [disabled]="status === 'loading'"
+            (click)="generate()">
+      @if (status === 'loading') {
+        <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+        Generating…
+      } @else {
+        <i class="bi bi-magic me-2"></i>Generate Examples
+      }
+    </button>
+
+    @if (status === 'success') {
+      <div class="alert alert-success mt-3 mb-0">
+        <i class="bi bi-check-circle-fill me-2"></i>
+        Generation started — running in the background.
+      </div>
+    }
+
+    @if (status === 'error') {
+      <div class="alert alert-danger mt-3 mb-0">
+        <i class="bi bi-exclamation-triangle-fill me-2"></i>
+        Request failed. Check logs or try again.
+      </div>
+    }
+
+  </div>
+</div>

--- a/src/app/admin/noun-examples/noun-examples-admin.component.ts
+++ b/src/app/admin/noun-examples/noun-examples-admin.component.ts
@@ -1,0 +1,34 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NounExamplesAdminService } from '../noun-examples-admin.service';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+@Component({
+  selector: 'app-noun-examples-admin',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './noun-examples-admin.component.html',
+})
+export class NounExamplesAdminComponent {
+  private readonly svc = inject(NounExamplesAdminService);
+
+  readonly langs = [
+    { code: 'it', label: 'Italiano' },
+    { code: 'en', label: 'English' },
+    { code: 'es', label: 'Español' },
+  ];
+
+  selectedLang = 'it';
+  limit: number | null = null;
+  status: Status = 'idle';
+
+  generate(): void {
+    this.status = 'loading';
+    this.svc.generateExamples(this.selectedLang, this.limit ?? undefined).subscribe({
+      next: () => { this.status = 'success'; },
+      error: () => { this.status = 'error'; },
+    });
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,6 +19,8 @@ import { CookiesComponent } from './legal/cookies/cookies.component';
 import { AboutComponent } from './about/about.component';
 import { DemoFlashcardComponent } from './demo-flashcard/demo-flashcard.component';
 import { LearnDeutschComponent } from './learn-deutsch/learn-deutsch.component';
+import { AdminLayoutComponent } from './admin/admin-layout.component';
+import { NounExamplesAdminComponent } from './admin/noun-examples/noun-examples-admin.component';
 
 export const routes: Routes = [
   {
@@ -88,6 +90,17 @@ export const routes: Routes = [
   {
     path: 'learn-deutsch',
     component: LearnDeutschComponent,
+  },
+
+  {
+    path: 'admin',
+    component: AdminLayoutComponent,
+    canActivate: [canActivateAuthRole],
+    data: { role: 'ADMIN' },
+    children: [
+      { path: '', redirectTo: 'noun-examples', pathMatch: 'full' },
+      { path: 'noun-examples', component: NounExamplesAdminComponent },
+    ],
   },
 
   {

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -59,6 +59,13 @@
       </mat-menu>
     </ng-container>
 
+    <ng-container *kaHasRoles="['ADMIN']">
+      <a routerLink="/admin/noun-examples" mat-button class="rounded-pill text-white"
+        routerLinkActive="bg-white bg-opacity-10">
+        <mat-icon class="text-white">admin_panel_settings</mat-icon> Admin
+      </a>
+    </ng-container>
+
     <div class="vr text-white opacity-25 mx-2 d-none d-lg-inline-flex"></div>
 
     <!-- Language switcher -->
@@ -137,6 +144,14 @@
       <a mat-button class="d-flex w-100 justify-content-start rounded-pill mb-1 text-white"
         routerLink="/settings/roles" routerLinkActive="bg-white bg-opacity-10" (click)="closeMobileMenu()">
         <mat-icon class="me-2 text-white">manage_accounts</mat-icon> {{ 'header.roles' | transloco }}
+      </a>
+      <mat-divider class="my-2"></mat-divider>
+    </ng-container>
+
+    <ng-container *kaHasRoles="['ADMIN']">
+      <a mat-button class="d-flex w-100 justify-content-start rounded-pill mb-1 text-white"
+        routerLink="/admin/noun-examples" routerLinkActive="bg-white bg-opacity-10" (click)="closeMobileMenu()">
+        <mat-icon class="me-2 text-white">admin_panel_settings</mat-icon> Admin
       </a>
       <mat-divider class="my-2"></mat-divider>
     </ng-container>

--- a/src/app/learn-deutsch/learn-deutsch.component.html
+++ b/src/app/learn-deutsch/learn-deutsch.component.html
@@ -117,6 +117,9 @@
             <div class="mt-3">
               <span class="badge bg-light text-dark border fs-6">{{ current.hint }}</span>
             </div>
+            @if (current.translation) {
+              <p class="text-muted small mb-0 mt-2">{{ current.translation }}</p>
+            }
           }
         </div>
       </div>
@@ -137,9 +140,11 @@
 
       <!-- Feedback + timer + Next -->
       @if (isAnswered) {
-        <div class="progress mt-3" style="height: 4px;">
-          <div class="progress-bar bg-secondary" [style.width.%]="timerProgress"></div>
-        </div>
+        @if (!isHeld) {
+          <div class="progress mt-3" style="height: 4px;">
+            <div class="progress-bar bg-secondary" [style.width.%]="timerProgress"></div>
+          </div>
+        }
         <div class="d-flex align-items-center justify-content-between mt-2">
           @if (isCorrect) {
             <span class="badge bg-success px-3 py-2 fs-6">
@@ -151,10 +156,38 @@
               — {{ current.correctAnswer }}
             </span>
           }
-          <button class="btn btn-primary" (click)="next()">
-            {{ 'learnDeutsch.next' | transloco }} <i class="bi bi-arrow-right ms-1"></i>
-          </button>
+          <div class="d-flex gap-2">
+            @if (!isHeld) {
+              <button class="btn btn-sm btn-outline-secondary" (click)="hold()">
+                <i class="bi bi-pause-fill me-1"></i>Hold
+              </button>
+            }
+            <button class="btn btn-primary" (click)="next()">
+              {{ 'learnDeutsch.next' | transloco }} <i class="bi bi-arrow-right ms-1"></i>
+            </button>
+          </div>
         </div>
+
+        <!-- Examples — shown below the action bar -->
+        @if (current.examples.length > 0) {
+          <div class="mt-3 pt-3 border-top">
+            @for (ex of current.examples; track ex.sentenceDe) {
+              <p class="small fst-italic text-secondary mb-1">{{ ex.sentenceDe }}</p>
+              <p class="small text-muted mb-2">{{ ex.sentenceTranslation }}</p>
+            }
+            <div>
+              <button class="btn btn-sm" (click)="copyExample()"
+                      [class.btn-outline-secondary]="!copied"
+                      [class.btn-success]="copied">
+                @if (copied) {
+                  <i class="bi bi-check-lg me-1"></i>Copied!
+                } @else {
+                  <i class="bi bi-clipboard me-1"></i>Copy
+                }
+              </button>
+            </div>
+          </div>
+        }
       }
 
     </div>

--- a/src/app/learn-deutsch/learn-deutsch.component.ts
+++ b/src/app/learn-deutsch/learn-deutsch.component.ts
@@ -1,14 +1,14 @@
 import { Component, inject, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
-import { TranslocoModule } from '@jsverse/transloco';
+import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
 import { LearnDeutschService } from './learn-deutsch.service';
 import { DeutschNoun, PracticeItem } from './learn-deutsch.model';
 
 type PageState = 'idle' | 'loading' | 'error' | 'practicing' | 'complete';
 type Mode = 'articles' | 'plural';
 
-const TIMER_MS = 3000;
+const TIMER_MS = 10000;
 const TIMER_STEP_MS = 50;
 
 function shuffle<T>(arr: T[]): T[] {
@@ -28,6 +28,7 @@ function shuffle<T>(arr: T[]): T[] {
 })
 export class LearnDeutschComponent implements OnDestroy {
   private readonly svc = inject(LearnDeutschService);
+  private readonly transloco = inject(TranslocoService);
 
   readonly articleOptions = ['der', 'die', 'das'];
   readonly SESSION_SIZE = 20;
@@ -39,6 +40,8 @@ export class LearnDeutschComponent implements OnDestroy {
   currentIndex = 0;
   selected: string | null = null;
   isAnswered = false;
+  isHeld = false;
+  copied = false;
   correctCount = 0;
   wrongCount = 0;
   timerProgress = 100;
@@ -68,7 +71,7 @@ export class LearnDeutschComponent implements OnDestroy {
   start(): void {
     this.clearTimer();
     this.state = 'loading';
-    this.svc.getNouns().subscribe({
+    this.svc.getNouns(100, this.transloco.getActiveLang()).subscribe({
       next: (data) => {
         const items = this.mode === 'articles'
           ? this.buildArticleItems(data)
@@ -94,6 +97,20 @@ export class LearnDeutschComponent implements OnDestroy {
   next(): void {
     this.clearTimer();
     this.advance();
+  }
+
+  copyExample(): void {
+    const text = this.current.examples
+      .map(ex => `${ex.sentenceDe}\n${ex.sentenceTranslation}`)
+      .join('\n\n');
+    navigator.clipboard.writeText(text).catch(() => {});
+    this.copied = true;
+    setTimeout(() => { this.copied = false; }, 2000);
+  }
+
+  hold(): void {
+    this.clearTimer();
+    this.isHeld = true;
   }
 
   restart(): void {
@@ -141,6 +158,7 @@ export class LearnDeutschComponent implements OnDestroy {
     this.currentIndex = 0;
     this.selected = null;
     this.isAnswered = false;
+    this.isHeld = false;
     this.correctCount = 0;
     this.wrongCount = 0;
     this.state = 'practicing';
@@ -152,6 +170,8 @@ export class LearnDeutschComponent implements OnDestroy {
       correctAnswer: n.article,
       hint: `${n.article} ${n.wordDe}`,
       options: this.articleOptions,
+      translation: n.translation,
+      examples: n.examples ?? [],
     }));
   }
 
@@ -161,6 +181,8 @@ export class LearnDeutschComponent implements OnDestroy {
       correctAnswer: n.pluralDe,
       hint: n.pluralDe,
       options: shuffle([n.pluralDe, ...n.pluralDistractors.slice(0, 3)]),
+      translation: n.translation,
+      examples: n.examples ?? [],
     }));
   }
 
@@ -171,6 +193,8 @@ export class LearnDeutschComponent implements OnDestroy {
       this.currentIndex++;
       this.selected = null;
       this.isAnswered = false;
+      this.isHeld = false;
+      this.copied = false;
     }
   }
 }

--- a/src/app/learn-deutsch/learn-deutsch.model.ts
+++ b/src/app/learn-deutsch/learn-deutsch.model.ts
@@ -1,9 +1,16 @@
+export interface ExampleView {
+  sentenceDe: string;
+  sentenceTranslation: string;
+}
+
 export interface DeutschNoun {
   uuid: string;
   wordDe: string;
   article: string;
   pluralDe: string;
   pluralDistractors: string[];
+  translation: string | null;
+  examples: ExampleView[];
 }
 
 export interface PracticeItem {
@@ -11,4 +18,6 @@ export interface PracticeItem {
   correctAnswer: string;
   hint: string;
   options: string[];
+  translation: string | null;
+  examples: ExampleView[];
 }

--- a/src/app/learn-deutsch/learn-deutsch.service.ts
+++ b/src/app/learn-deutsch/learn-deutsch.service.ts
@@ -9,8 +9,8 @@ export class LearnDeutschService {
   private readonly baseUrl = `${env.apiBaseUrl}/public`;
   private readonly http = inject(HttpClient);
 
-  getNouns(limit = 100): Observable<DeutschNoun[]> {
-    const params = new HttpParams().set('limit', limit);
-    return this.http.get<DeutschNoun[]>(`${this.baseUrl}/nouns/de-it`, { params });
+  getNouns(limit = 100, lang = 'en'): Observable<DeutschNoun[]> {
+    const params = new HttpParams().set('limit', limit).set('lang', lang);
+    return this.http.get<DeutschNoun[]>(`${this.baseUrl}/nouns/de`, { params });
   }
 }


### PR DESCRIPTION
…neration

- Update learn-deutsch service: endpoint /nouns/de-it → /nouns/de, add lang param
- Add ExampleView/translation fields to model and propagate through practice items
- Show translation and example sentences after answering; 10s auto-advance timer
- Add Hold button to pause timer; Copy button below examples
- Add admin layout with sidebar nav and NounExamplesAdminComponent
- Wire admin route (ADMIN role guard) and header link for admin users