### PR TITLE
Add admin UI for DE noun translation generation

### DIFF
--- a/src/app/admin/admin-layout.component.html
+++ b/src/app/admin/admin-layout.component.html
@@ -11,6 +11,12 @@
           </div>
         </div>
         <div class="list-group list-group-flush">
+          <a routerLink="/admin/noun-translations"
+             routerLinkActive="active bg-primary text-white"
+             class="list-group-item list-group-item-action d-flex align-items-center gap-2 py-3">
+            <i class="bi bi-translate"></i>
+            <span>Noun Translations</span>
+          </a>
           <a routerLink="/admin/noun-examples"
              routerLinkActive="active bg-primary text-white"
              class="list-group-item list-group-item-action d-flex align-items-center gap-2 py-3">

--- a/src/app/admin/noun-examples-admin.service.ts
+++ b/src/app/admin/noun-examples-admin.service.ts
@@ -15,4 +15,12 @@ export class NounExamplesAdminService {
     }
     return this.http.post<void>(`${this.baseUrl}/nouns/de/examples/generate`, null, { params });
   }
+
+  generateTranslations(lang: string, limit?: number): Observable<void> {
+    let params = new HttpParams().set('lang', lang);
+    if (limit != null) {
+      params = params.set('limit', limit);
+    }
+    return this.http.post<void>(`${this.baseUrl}/nouns/de/translations/generate`, null, { params });
+  }
 }

--- a/src/app/admin/noun-translations/noun-translations-admin.component.html
+++ b/src/app/admin/noun-translations/noun-translations-admin.component.html
@@ -1,0 +1,50 @@
+<h4 class="fw-bold mb-1">Generate DE Noun Translations</h4>
+<p class="text-muted mb-4">Triggers async generation of missing translations for German nouns.</p>
+
+<div class="card border-0 shadow-sm" style="max-width: 480px;">
+  <div class="card-body p-4">
+
+    <div class="mb-3">
+      <label class="form-label fw-semibold">Target language</label>
+      <select class="form-select" [(ngModel)]="selectedLang">
+        @for (lang of langs; track lang.code) {
+          <option [value]="lang.code">{{ lang.label }}</option>
+        }
+      </select>
+    </div>
+
+    <div class="mb-4">
+      <label class="form-label fw-semibold">
+        Limit <span class="text-muted fw-normal">(optional — leave empty for all)</span>
+      </label>
+      <input type="number" class="form-control" min="1"
+             [(ngModel)]="limit" placeholder="e.g. 10">
+    </div>
+
+    <button class="btn btn-primary w-100"
+            [disabled]="status === 'loading'"
+            (click)="generate()">
+      @if (status === 'loading') {
+        <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+        Generating…
+      } @else {
+        <i class="bi bi-translate me-2"></i>Generate Translations
+      }
+    </button>
+
+    @if (status === 'success') {
+      <div class="alert alert-success mt-3 mb-0">
+        <i class="bi bi-check-circle-fill me-2"></i>
+        Generation started — running in the background.
+      </div>
+    }
+
+    @if (status === 'error') {
+      <div class="alert alert-danger mt-3 mb-0">
+        <i class="bi bi-exclamation-triangle-fill me-2"></i>
+        Request failed. Check logs or try again.
+      </div>
+    }
+
+  </div>
+</div>

--- a/src/app/admin/noun-translations/noun-translations-admin.component.ts
+++ b/src/app/admin/noun-translations/noun-translations-admin.component.ts
@@ -1,0 +1,34 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NounExamplesAdminService } from '../noun-examples-admin.service';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+@Component({
+  selector: 'app-noun-translations-admin',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './noun-translations-admin.component.html',
+})
+export class NounTranslationsAdminComponent {
+  private readonly svc = inject(NounExamplesAdminService);
+
+  readonly langs = [
+    { code: 'it', label: 'Italiano' },
+    { code: 'en', label: 'English' },
+    { code: 'es', label: 'Español' },
+  ];
+
+  selectedLang = 'it';
+  limit: number | null = null;
+  status: Status = 'idle';
+
+  generate(): void {
+    this.status = 'loading';
+    this.svc.generateTranslations(this.selectedLang, this.limit ?? undefined).subscribe({
+      next: () => { this.status = 'success'; },
+      error: () => { this.status = 'error'; },
+    });
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -21,6 +21,7 @@ import { DemoFlashcardComponent } from './demo-flashcard/demo-flashcard.componen
 import { LearnDeutschComponent } from './learn-deutsch/learn-deutsch.component';
 import { AdminLayoutComponent } from './admin/admin-layout.component';
 import { NounExamplesAdminComponent } from './admin/noun-examples/noun-examples-admin.component';
+import { NounTranslationsAdminComponent } from './admin/noun-translations/noun-translations-admin.component';
 
 export const routes: Routes = [
   {
@@ -100,6 +101,7 @@ export const routes: Routes = [
     children: [
       { path: '', redirectTo: 'noun-examples', pathMatch: 'full' },
       { path: 'noun-examples', component: NounExamplesAdminComponent },
+      { path: 'noun-translations', component: NounTranslationsAdminComponent },
     ],
   },
 


### PR DESCRIPTION
- Add generateTranslations() to NounExamplesAdminService calling POST /admin/nouns/de/translations/generate
- Add NounTranslationsAdminComponent with lang select and optional limit
- Register /admin/noun-translations child route and sidebar entry