### PR TITLE
Add German stories assessment UI and admin generator

### DIFF
--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -52,7 +52,7 @@
     "deutsch": {
       "title": "Deutsch kostenlos üben",
       "subtitle": "Deutsche Nomen üben — Artikel und Pluralformen. Kein Konto nötig.",
-      "cta": "Deutsch üben"
+      "cta": "Deutsch lernen"
     }
   },
   "demo": {
@@ -129,5 +129,50 @@
     "loginGoogle": "Mit Google anmelden",
     "successMessage": "✅ Überprüfe deine E-Mail, um die Registrierung abzuschließen.",
     "errorMessage": "❌ Etwas ist schiefgelaufen."
+  },
+  "learnDeutschStories": {
+    "title": "Deutscher Geschichten-Test",
+    "subtitle": "Lies eine kurze deutsche Geschichte und fülle die Lücken — sofort bewertet. Kein Konto nötig.",
+    "loading": "Geschichten werden geladen…",
+    "empty": "Noch keine Geschichten verfügbar.",
+    "errorTitle": "Geschichten konnten nicht geladen werden",
+    "errorMessage": "Bitte überprüfe deine Verbindung und versuche es erneut.",
+    "retry": "Erneut versuchen",
+    "start": "Starten",
+    "backToStories": "Zurück zu den Geschichten",
+    "check": "Antworten prüfen",
+    "tryAgain": "Nochmal versuchen",
+    "score": "{{ correct }} / {{ total }} richtig",
+    "answered": "{{ answered }} von {{ total }} ausgefüllt",
+    "wantOwnWords": "Möchtest du deinen eigenen Wortschatz üben?",
+    "createFreeAccount": "Kostenloses Konto erstellen",
+    "category": {
+      "ARTICLE": "Artikel",
+      "ADJECTIVE_ENDING": "Adjektivendung",
+      "PRONOUN": "Pronomen",
+      "PREPOSITION": "Präposition",
+      "VERB_FORM": "Verbform"
+    },
+    "case": {
+      "NOMINATIV": "Nominativ",
+      "AKKUSATIV": "Akkusativ",
+      "DATIV": "Dativ",
+      "GENITIV": "Genitiv"
+    }
+  },
+  "learnDeutschHub": {
+    "title": "Deutsch lernen",
+    "subtitle": "Wähle, wie du üben möchtest — kein Konto nötig.",
+    "startBtn": "Starten",
+    "articles": {
+      "title": "Artikel & Plural",
+      "description": "Schnelle Übungen zu der/die/das und Pluralformen."
+    },
+    "stories": {
+      "title": "Geschichten-Test",
+      "description": "Lies eine kurze Geschichte und fülle die Lücken — sofort bewertet."
+    },
+    "wantOwnWords": "Möchtest du deinen eigenen Wortschatz üben?",
+    "createFreeAccount": "Kostenloses Konto erstellen"
   }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -52,7 +52,7 @@
     "deutsch": {
       "title": "Practice German for free",
       "subtitle": "Practice German nouns — articles and plural forms. No account needed.",
-      "cta": "Try German Practice"
+      "cta": "Learn German"
     }
   },
   "demo": {
@@ -129,5 +129,50 @@
     "loginGoogle": "Log in with Google",
     "successMessage": "✅ Check your email to complete registration.",
     "errorMessage": "❌ Something went wrong."
+  },
+  "learnDeutschStories": {
+    "title": "German Story Assessment",
+    "subtitle": "Read a short German story and fill the gaps — graded instantly. No account needed.",
+    "loading": "Loading stories…",
+    "empty": "No stories available yet.",
+    "errorTitle": "Could not load stories",
+    "errorMessage": "Please check your connection and try again.",
+    "retry": "Retry",
+    "start": "Start",
+    "backToStories": "Back to stories",
+    "check": "Check answers",
+    "tryAgain": "Try again",
+    "score": "{{ correct }} / {{ total }} correct",
+    "answered": "{{ answered }} of {{ total }} filled",
+    "wantOwnWords": "Want to practice your own vocabulary?",
+    "createFreeAccount": "Create a free account",
+    "category": {
+      "ARTICLE": "Article",
+      "ADJECTIVE_ENDING": "Adjective ending",
+      "PRONOUN": "Pronoun",
+      "PREPOSITION": "Preposition",
+      "VERB_FORM": "Verb form"
+    },
+    "case": {
+      "NOMINATIV": "Nominative",
+      "AKKUSATIV": "Accusative",
+      "DATIV": "Dative",
+      "GENITIV": "Genitive"
+    }
+  },
+  "learnDeutschHub": {
+    "title": "Learn German",
+    "subtitle": "Pick how you want to practice — no account needed.",
+    "startBtn": "Start",
+    "articles": {
+      "title": "Articles & Plural",
+      "description": "Quick drills on der/die/das and plural forms."
+    },
+    "stories": {
+      "title": "Story Assessment",
+      "description": "Read a short story and fill the gaps — graded instantly."
+    },
+    "wantOwnWords": "Want to practice your own vocabulary?",
+    "createFreeAccount": "Create a free account"
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -52,7 +52,7 @@
     "deutsch": {
       "title": "Practica alemán gratis",
       "subtitle": "Practica sustantivos alemanes — artículos y plurales. Sin cuenta.",
-      "cta": "Practicar alemán"
+      "cta": "Aprender alemán"
     }
   },
   "demo": {
@@ -129,5 +129,50 @@
     "loginGoogle": "Iniciar sesión con Google",
     "successMessage": "✅ Revisa tu correo para completar el registro.",
     "errorMessage": "❌ Algo salió mal."
+  },
+  "learnDeutschStories": {
+    "title": "Evaluación con historias en alemán",
+    "subtitle": "Lee una historia corta en alemán y completa los huecos — corrección instantánea. Sin cuenta.",
+    "loading": "Cargando historias…",
+    "empty": "Aún no hay historias disponibles.",
+    "errorTitle": "No se pudieron cargar las historias",
+    "errorMessage": "Comprueba tu conexión e inténtalo de nuevo.",
+    "retry": "Reintentar",
+    "start": "Empezar",
+    "backToStories": "Volver a las historias",
+    "check": "Comprobar respuestas",
+    "tryAgain": "Intentar de nuevo",
+    "score": "{{ correct }} / {{ total }} correctas",
+    "answered": "{{ answered }} de {{ total }} completados",
+    "wantOwnWords": "¿Quieres practicar tu propio vocabulario?",
+    "createFreeAccount": "Crea una cuenta gratuita",
+    "category": {
+      "ARTICLE": "Artículo",
+      "ADJECTIVE_ENDING": "Terminación del adjetivo",
+      "PRONOUN": "Pronombre",
+      "PREPOSITION": "Preposición",
+      "VERB_FORM": "Forma verbal"
+    },
+    "case": {
+      "NOMINATIV": "Nominativo",
+      "AKKUSATIV": "Acusativo",
+      "DATIV": "Dativo",
+      "GENITIV": "Genitivo"
+    }
+  },
+  "learnDeutschHub": {
+    "title": "Aprender alemán",
+    "subtitle": "Elige cómo quieres practicar — sin cuenta.",
+    "startBtn": "Empezar",
+    "articles": {
+      "title": "Artículos y plurales",
+      "description": "Ejercicios rápidos de der/die/das y plurales."
+    },
+    "stories": {
+      "title": "Evaluación con historias",
+      "description": "Lee una historia corta y completa los huecos — corrección instantánea."
+    },
+    "wantOwnWords": "¿Quieres practicar tu propio vocabulario?",
+    "createFreeAccount": "Crea una cuenta gratuita"
   }
 }

--- a/public/i18n/it.json
+++ b/public/i18n/it.json
@@ -52,7 +52,7 @@
     "deutsch": {
       "title": "Pratica il tedesco gratis",
       "subtitle": "Pratica i sostantivi tedeschi — articoli e plurali. Senza account.",
-      "cta": "Prova la pratica tedesco"
+      "cta": "Impara il tedesco"
     }
   },
   "demo": {
@@ -129,5 +129,50 @@
     "loginGoogle": "Accedi con Google",
     "successMessage": "✅ Controlla la tua email per completare la registrazione.",
     "errorMessage": "❌ Qualcosa è andato storto."
+  },
+  "learnDeutschStories": {
+    "title": "Valutazione con storie tedesche",
+    "subtitle": "Leggi una breve storia in tedesco e completa gli spazi — correzione immediata. Senza account.",
+    "loading": "Caricamento storie…",
+    "empty": "Ancora nessuna storia disponibile.",
+    "errorTitle": "Impossibile caricare le storie",
+    "errorMessage": "Controlla la connessione e riprova.",
+    "retry": "Riprova",
+    "start": "Inizia",
+    "backToStories": "Torna alle storie",
+    "check": "Verifica risposte",
+    "tryAgain": "Riprova",
+    "score": "{{ correct }} / {{ total }} corrette",
+    "answered": "{{ answered }} di {{ total }} completati",
+    "wantOwnWords": "Vuoi esercitarti con il tuo vocabolario?",
+    "createFreeAccount": "Crea un account gratuito",
+    "category": {
+      "ARTICLE": "Articolo",
+      "ADJECTIVE_ENDING": "Desinenza aggettivo",
+      "PRONOUN": "Pronome",
+      "PREPOSITION": "Preposizione",
+      "VERB_FORM": "Forma verbale"
+    },
+    "case": {
+      "NOMINATIV": "Nominativo",
+      "AKKUSATIV": "Accusativo",
+      "DATIV": "Dativo",
+      "GENITIV": "Genitivo"
+    }
+  },
+  "learnDeutschHub": {
+    "title": "Impara il tedesco",
+    "subtitle": "Scegli come esercitarti — senza account.",
+    "startBtn": "Inizia",
+    "articles": {
+      "title": "Articoli e plurali",
+      "description": "Esercizi veloci su der/die/das e i plurali."
+    },
+    "stories": {
+      "title": "Valutazione storie",
+      "description": "Leggi una breve storia e completa gli spazi — correzione immediata."
+    },
+    "wantOwnWords": "Vuoi esercitarti con il tuo vocabolario?",
+    "createFreeAccount": "Crea un account gratuito"
   }
 }

--- a/src/app/admin/admin-layout.component.html
+++ b/src/app/admin/admin-layout.component.html
@@ -23,6 +23,12 @@
             <i class="bi bi-magic"></i>
             <span>Noun Examples</span>
           </a>
+          <a routerLink="/admin/stories"
+             routerLinkActive="active bg-primary text-white"
+             class="list-group-item list-group-item-action d-flex align-items-center gap-2 py-3">
+            <i class="bi bi-card-text"></i>
+            <span>DE Stories</span>
+          </a>
         </div>
       </div>
     </div>

--- a/src/app/admin/stories/stories-admin.component.html
+++ b/src/app/admin/stories/stories-admin.component.html
@@ -1,0 +1,69 @@
+<h4 class="fw-bold mb-1">Generate DE Story</h4>
+<p class="text-muted mb-4">Triggers Claude generation of a German gap-fill story for the chosen level, topic and length.</p>
+
+<div class="card border-0 shadow-sm" style="max-width: 480px;">
+  <div class="card-body p-4">
+
+    <div class="mb-3">
+      <label class="form-label fw-semibold">Level</label>
+      <select class="form-select" [(ngModel)]="level">
+        @for (l of levels; track l) {
+          <option [value]="l">{{ l }}</option>
+        }
+      </select>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label fw-semibold">Topic</label>
+      <input type="text" class="form-control" maxlength="64"
+             [(ngModel)]="topic" placeholder="e.g. food, travel, music">
+      <div class="form-text">Max 64 characters.</div>
+    </div>
+
+    <div class="mb-4">
+      <label class="form-label fw-semibold">Length</label>
+      <select class="form-select" [(ngModel)]="length">
+        @for (len of lengths; track len.value) {
+          <option [value]="len.value">{{ len.label }}</option>
+        }
+      </select>
+    </div>
+
+    <button class="btn btn-primary w-100"
+            [disabled]="!canSubmit"
+            (click)="generate()">
+      @if (status === 'loading') {
+        <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+        Generating…
+      } @else {
+        <i class="bi bi-magic me-2"></i>Generate Story
+      }
+    </button>
+
+    @if (status === 'error') {
+      <div class="alert alert-danger mt-3 mb-0">
+        <i class="bi bi-exclamation-triangle-fill me-2"></i>
+        Request failed. Check logs or try again.
+      </div>
+    }
+
+  </div>
+</div>
+
+@if (status === 'success' && created) {
+  <div class="card border-0 shadow-sm mt-4" style="max-width: 640px;">
+    <div class="card-header bg-success text-white">
+      <i class="bi bi-check-circle-fill me-2"></i>Story created
+    </div>
+    <div class="card-body p-4">
+      <div class="d-flex justify-content-between align-items-start mb-2">
+        <h5 class="fw-bold mb-0">{{ created.title }}</h5>
+        <span class="badge bg-dark">{{ created.level }}</span>
+      </div>
+      <p class="text-muted small text-capitalize mb-3">
+        {{ created.topic }} · {{ created.gaps.length }} gaps
+      </p>
+      <p class="mb-0" style="white-space: pre-wrap;">{{ created.body }}</p>
+    </div>
+  </div>
+}

--- a/src/app/admin/stories/stories-admin.component.ts
+++ b/src/app/admin/stories/stories-admin.component.ts
@@ -1,0 +1,52 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { StoryDeAdminService, StoryLength } from '../story-de-admin.service';
+import { DeutschLevel, Story } from '../../learn-deutsch-stories/learn-deutsch-stories.model';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+@Component({
+  selector: 'app-stories-admin',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './stories-admin.component.html',
+})
+export class StoriesAdminComponent {
+  private readonly svc = inject(StoryDeAdminService);
+
+  readonly levels: DeutschLevel[] = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
+  readonly lengths: { value: StoryLength; label: string }[] = [
+    { value: 'SHORT', label: 'Short (3–4 sentences)' },
+    { value: 'MEDIUM', label: 'Medium (6–8 sentences)' },
+    { value: 'LONG', label: 'Long (10–12 sentences)' },
+  ];
+
+  level: DeutschLevel = 'A2';
+  topic = '';
+  length: StoryLength = 'SHORT';
+
+  status: Status = 'idle';
+  created: Story | null = null;
+
+  get canSubmit(): boolean {
+    return this.topic.trim().length > 0 && this.status !== 'loading';
+  }
+
+  generate(): void {
+    if (!this.canSubmit) return;
+    this.status = 'loading';
+    this.created = null;
+    this.svc.generate({
+      level: this.level,
+      topic: this.topic.trim(),
+      length: this.length,
+    }).subscribe({
+      next: (story) => {
+        this.created = story;
+        this.status = 'success';
+      },
+      error: () => { this.status = 'error'; },
+    });
+  }
+}

--- a/src/app/admin/story-de-admin.service.ts
+++ b/src/app/admin/story-de-admin.service.ts
@@ -1,0 +1,23 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as env } from '../../environments/environment';
+import { DeutschLevel, Story } from '../learn-deutsch-stories/learn-deutsch-stories.model';
+
+export type StoryLength = 'SHORT' | 'MEDIUM' | 'LONG';
+
+export interface StoryGenerationRequest {
+  level: DeutschLevel;
+  topic: string;
+  length: StoryLength;
+}
+
+@Injectable({ providedIn: 'root' })
+export class StoryDeAdminService {
+  private readonly baseUrl = `${env.apiBaseUrl}/admin/deutsch/stories`;
+  private readonly http = inject(HttpClient);
+
+  generate(request: StoryGenerationRequest): Observable<Story> {
+    return this.http.post<Story>(`${this.baseUrl}/generate`, request);
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,9 +19,12 @@ import { CookiesComponent } from './legal/cookies/cookies.component';
 import { AboutComponent } from './about/about.component';
 import { DemoFlashcardComponent } from './demo-flashcard/demo-flashcard.component';
 import { LearnDeutschComponent } from './learn-deutsch/learn-deutsch.component';
+import { LearnDeutschHubComponent } from './learn-deutsch-hub/learn-deutsch-hub.component';
+import { LearnDeutschStoriesComponent } from './learn-deutsch-stories/learn-deutsch-stories.component';
 import { AdminLayoutComponent } from './admin/admin-layout.component';
 import { NounExamplesAdminComponent } from './admin/noun-examples/noun-examples-admin.component';
 import { NounTranslationsAdminComponent } from './admin/noun-translations/noun-translations-admin.component';
+import { StoriesAdminComponent } from './admin/stories/stories-admin.component';
 
 export const routes: Routes = [
   {
@@ -90,7 +93,17 @@ export const routes: Routes = [
 
   {
     path: 'learn-deutsch',
+    component: LearnDeutschHubComponent,
+  },
+
+  {
+    path: 'learn-deutsch/practice',
     component: LearnDeutschComponent,
+  },
+
+  {
+    path: 'learn-deutsch/stories',
+    component: LearnDeutschStoriesComponent,
   },
 
   {
@@ -102,6 +115,7 @@ export const routes: Routes = [
       { path: '', redirectTo: 'noun-examples', pathMatch: 'full' },
       { path: 'noun-examples', component: NounExamplesAdminComponent },
       { path: 'noun-translations', component: NounTranslationsAdminComponent },
+      { path: 'stories', component: StoriesAdminComponent },
     ],
   },
 

--- a/src/app/learn-deutsch-hub/learn-deutsch-hub.component.html
+++ b/src/app/learn-deutsch-hub/learn-deutsch-hub.component.html
@@ -1,0 +1,56 @@
+<div class="container py-4">
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+
+      <div class="text-center mb-4">
+        <div class="fs-1">🇩🇪</div>
+        <h3 class="mt-2 fw-bold">{{ 'learnDeutschHub.title' | transloco }}</h3>
+        <p class="text-muted">{{ 'learnDeutschHub.subtitle' | transloco }}</p>
+      </div>
+
+      <div class="row g-3">
+
+        <!-- Articles & Plural practice -->
+        <div class="col-12 col-md-6">
+          <a routerLink="/learn-deutsch/practice"
+             class="card h-100 border-0 shadow-sm text-decoration-none text-reset">
+            <div class="card-body text-center py-4">
+              <i class="bi bi-journal-text fs-1 text-primary"></i>
+              <h5 class="fw-bold mt-3 mb-1">{{ 'learnDeutschHub.articles.title' | transloco }}</h5>
+              <p class="text-muted small mb-0">{{ 'learnDeutschHub.articles.description' | transloco }}</p>
+            </div>
+            <div class="card-footer bg-transparent border-0 text-center pb-3">
+              <span class="btn btn-primary">
+                <i class="bi bi-play-fill me-1"></i>{{ 'learnDeutschHub.startBtn' | transloco }}
+              </span>
+            </div>
+          </a>
+        </div>
+
+        <!-- Story assessment -->
+        <div class="col-12 col-md-6">
+          <a routerLink="/learn-deutsch/stories"
+             class="card h-100 border-0 shadow-sm text-decoration-none text-reset">
+            <div class="card-body text-center py-4">
+              <i class="bi bi-card-text fs-1 text-success"></i>
+              <h5 class="fw-bold mt-3 mb-1">{{ 'learnDeutschHub.stories.title' | transloco }}</h5>
+              <p class="text-muted small mb-0">{{ 'learnDeutschHub.stories.description' | transloco }}</p>
+            </div>
+            <div class="card-footer bg-transparent border-0 text-center pb-3">
+              <span class="btn btn-success">
+                <i class="bi bi-play-fill me-1"></i>{{ 'learnDeutschHub.startBtn' | transloco }}
+              </span>
+            </div>
+          </a>
+        </div>
+
+      </div>
+
+      <p class="mt-4 mb-0 text-center small text-muted">
+        {{ 'learnDeutschHub.wantOwnWords' | transloco }}
+        <a routerLink="/register" class="fw-semibold">{{ 'learnDeutschHub.createFreeAccount' | transloco }}</a>
+      </p>
+
+    </div>
+  </div>
+</div>

--- a/src/app/learn-deutsch-hub/learn-deutsch-hub.component.ts
+++ b/src/app/learn-deutsch-hub/learn-deutsch-hub.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+
+@Component({
+  selector: 'app-learn-deutsch-hub',
+  standalone: true,
+  imports: [RouterLink, TranslocoModule],
+  templateUrl: './learn-deutsch-hub.component.html',
+})
+export class LearnDeutschHubComponent {}

--- a/src/app/learn-deutsch-stories/learn-deutsch-stories.component.html
+++ b/src/app/learn-deutsch-stories/learn-deutsch-stories.component.html
@@ -1,0 +1,178 @@
+<div class="container py-4">
+
+  <!-- Loading list -->
+  @if (state === 'loading') {
+  <div class="text-center py-5">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Loading…</span>
+    </div>
+    <p class="mt-3 text-muted">{{ 'learnDeutschStories.loading' | transloco }}</p>
+  </div>
+  }
+
+  <!-- List error -->
+  @if (state === 'error') {
+  <div class="row justify-content-center">
+    <div class="col-md-5 text-center py-5">
+      <i class="bi bi-exclamation-triangle-fill fs-1 text-danger"></i>
+      <h5 class="mt-3">{{ 'learnDeutschStories.errorTitle' | transloco }}</h5>
+      <p class="text-muted">{{ 'learnDeutschStories.errorMessage' | transloco }}</p>
+      <button class="btn btn-outline-primary" (click)="loadList()">
+        <i class="bi bi-arrow-clockwise me-1"></i>{{ 'learnDeutschStories.retry' | transloco }}
+      </button>
+    </div>
+  </div>
+  }
+
+  <!-- Story list -->
+  @if (state === 'list') {
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <div class="text-center mb-4">
+        <div class="fs-1">🇩🇪</div>
+        <h3 class="mt-2 fw-bold">{{ 'learnDeutschStories.title' | transloco }}</h3>
+        <p class="text-muted">{{ 'learnDeutschStories.subtitle' | transloco }}</p>
+      </div>
+
+      @if (stories.length === 0) {
+        <p class="text-center text-muted py-4">{{ 'learnDeutschStories.empty' | transloco }}</p>
+      }
+
+      <div class="row g-3">
+        @for (s of stories; track s.uuid) {
+          <div class="col-12 col-md-6">
+            <div class="card h-100 border-0 shadow-sm" style="cursor: pointer;"
+                 (click)="openStory(s.uuid)">
+              <div class="card-body">
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                  <span class="badge {{ levelBadgeClass(s.level) }}">{{ s.level }}</span>
+                  <span class="badge bg-light text-dark border text-capitalize">{{ s.topic }}</span>
+                </div>
+                <h5 class="fw-bold mb-0">{{ s.title }}</h5>
+              </div>
+              <div class="card-footer bg-transparent border-0 text-end">
+                <span class="text-primary small fw-semibold">
+                  {{ 'learnDeutschStories.start' | transloco }} <i class="bi bi-arrow-right ms-1"></i>
+                </span>
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+
+      <p class="mt-4 mb-0 text-center small text-muted">
+        {{ 'learnDeutschStories.wantOwnWords' | transloco }}
+        <a routerLink="/register" class="fw-semibold">{{ 'learnDeutschStories.createFreeAccount' | transloco }}</a>
+      </p>
+    </div>
+  </div>
+  }
+
+  <!-- Loading single story -->
+  @if (state === 'storyLoading') {
+  <div class="text-center py-5">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Loading…</span>
+    </div>
+  </div>
+  }
+
+  <!-- Story error -->
+  @if (state === 'storyError') {
+  <div class="row justify-content-center">
+    <div class="col-md-5 text-center py-5">
+      <i class="bi bi-exclamation-triangle-fill fs-1 text-danger"></i>
+      <h5 class="mt-3">{{ 'learnDeutschStories.errorTitle' | transloco }}</h5>
+      <button class="btn btn-outline-secondary mt-2" (click)="backToList()">
+        <i class="bi bi-arrow-left me-1"></i>{{ 'learnDeutschStories.backToStories' | transloco }}
+      </button>
+    </div>
+  </div>
+  }
+
+  <!-- Assessment -->
+  @if (state === 'assess' && story) {
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+
+      <!-- Header -->
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <button class="btn btn-sm btn-outline-secondary" (click)="backToList()">
+          <i class="bi bi-arrow-left me-1"></i>{{ 'learnDeutschStories.backToStories' | transloco }}
+        </button>
+        <span class="badge {{ levelBadgeClass(story.level) }}">{{ story.level }}</span>
+      </div>
+
+      <h4 class="fw-bold mb-1">{{ story.title }}</h4>
+      <p class="text-muted small text-capitalize mb-3">{{ story.topic }}</p>
+
+      <!-- Result banner -->
+      @if (submitted) {
+        <div class="card border-0 shadow-sm mb-3"
+             [class.bg-success]="scorePercent === 100"
+             [class.bg-opacity-10]="true"
+             [class.bg-warning]="scorePercent < 100">
+          <div class="card-body text-center py-3">
+            <div class="fs-4 fw-bold">
+              {{ 'learnDeutschStories.score' | transloco: { correct: correctCount, total: totalGaps } }}
+            </div>
+            <div class="small text-muted">{{ scorePercent }}%</div>
+          </div>
+        </div>
+      }
+
+      <!-- Story body with gaps -->
+      <div class="card border-0 shadow-sm mb-3">
+        <div class="card-body" style="line-height: 2.4; font-size: 1.1rem;">
+          @for (seg of segments; track $index) {
+            @if (seg.kind === 'text') {
+              <span>{{ seg.text }}</span>
+            } @else {
+              <span class="d-inline-block align-middle mx-1">
+                <select class="form-select form-select-sm d-inline-block w-auto align-baseline"
+                        [ngClass]="gapSelectClass(seg.gap)"
+                        [disabled]="submitted"
+                        [value]="answers[seg.gap.position] || ''"
+                        [title]="(gapHintKey(seg.gap) | transloco)
+                                 + (gapCaseKey(seg.gap) ? ' · ' + (gapCaseKey(seg.gap)! | transloco) : '')"
+                        (change)="setAnswer(seg.gap.position, $any($event.target).value)">
+                  <option value="" disabled>—</option>
+                  @for (opt of seg.gap.options; track opt.text) {
+                    <option [value]="opt.text">{{ opt.text }}</option>
+                  }
+                </select>
+                @if (submitted && !isGapCorrect(seg.gap)) {
+                  <span class="badge bg-success ms-1">{{ correctAnswer(seg.gap) }}</span>
+                }
+              </span>
+            }
+          }
+        </div>
+      </div>
+
+      <!-- Actions -->
+      <div class="d-flex justify-content-between align-items-center">
+        <span class="text-muted small">
+          {{ 'learnDeutschStories.answered' | transloco: { answered: answeredCount, total: totalGaps } }}
+        </span>
+        @if (!submitted) {
+          <button class="btn btn-primary" [disabled]="!allAnswered" (click)="submit()">
+            <i class="bi bi-check2-circle me-1"></i>{{ 'learnDeutschStories.check' | transloco }}
+          </button>
+        } @else {
+          <div class="d-flex gap-2">
+            <button class="btn btn-outline-primary" (click)="retry()">
+              <i class="bi bi-arrow-clockwise me-1"></i>{{ 'learnDeutschStories.tryAgain' | transloco }}
+            </button>
+            <button class="btn btn-outline-secondary" (click)="backToList()">
+              {{ 'learnDeutschStories.backToStories' | transloco }}
+            </button>
+          </div>
+        }
+      </div>
+
+    </div>
+  </div>
+  }
+
+</div>

--- a/src/app/learn-deutsch-stories/learn-deutsch-stories.component.ts
+++ b/src/app/learn-deutsch-stories/learn-deutsch-stories.component.ts
@@ -1,0 +1,174 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { TranslocoModule } from '@jsverse/transloco';
+import { LearnDeutschStoriesService } from './learn-deutsch-stories.service';
+import {
+  DeutschLevel,
+  Story,
+  StoryGap,
+  StorySummary,
+} from './learn-deutsch-stories.model';
+
+type PageState =
+  | 'loading'
+  | 'error'
+  | 'list'
+  | 'storyLoading'
+  | 'storyError'
+  | 'assess';
+
+type Segment =
+  | { kind: 'text'; text: string }
+  | { kind: 'gap'; gap: StoryGap };
+
+const LEVEL_BADGE: Record<DeutschLevel, string> = {
+  A1: 'bg-success',
+  A2: 'bg-success',
+  B1: 'bg-primary',
+  B2: 'bg-primary',
+  C1: 'bg-dark',
+  C2: 'bg-dark',
+};
+
+@Component({
+  selector: 'app-learn-deutsch-stories',
+  standalone: true,
+  imports: [CommonModule, RouterLink, TranslocoModule],
+  templateUrl: './learn-deutsch-stories.component.html',
+})
+export class LearnDeutschStoriesComponent implements OnInit {
+  private readonly svc = inject(LearnDeutschStoriesService);
+
+  state: PageState = 'loading';
+  stories: StorySummary[] = [];
+  story: Story | null = null;
+  segments: Segment[] = [];
+  answers: Record<number, string> = {};
+  submitted = false;
+  correctCount = 0;
+
+  ngOnInit(): void {
+    this.loadList();
+  }
+
+  loadList(): void {
+    this.state = 'loading';
+    this.svc.getStories().subscribe({
+      next: (stories) => {
+        this.stories = stories;
+        this.state = 'list';
+      },
+      error: () => { this.state = 'error'; },
+    });
+  }
+
+  openStory(uuid: string): void {
+    this.state = 'storyLoading';
+    this.svc.getStory(uuid).subscribe({
+      next: (story) => this.initStory(story),
+      error: () => { this.state = 'storyError'; },
+    });
+  }
+
+  backToList(): void {
+    this.story = null;
+    this.state = 'list';
+  }
+
+  setAnswer(position: number, value: string): void {
+    if (this.submitted) return;
+    this.answers[position] = value;
+  }
+
+  submit(): void {
+    if (!this.story || !this.allAnswered) return;
+    this.correctCount = this.story.gaps.filter((g) => this.isGapCorrect(g)).length;
+    this.submitted = true;
+  }
+
+  retry(): void {
+    if (this.story) this.initStory(this.story);
+  }
+
+  get totalGaps(): number {
+    return this.story?.gaps.length ?? 0;
+  }
+
+  get answeredCount(): number {
+    return Object.keys(this.answers).length;
+  }
+
+  get allAnswered(): boolean {
+    return this.totalGaps > 0 && this.answeredCount === this.totalGaps;
+  }
+
+  get scorePercent(): number {
+    return this.totalGaps === 0
+      ? 0
+      : Math.round((this.correctCount / this.totalGaps) * 100);
+  }
+
+  levelBadgeClass(level: DeutschLevel): string {
+    return LEVEL_BADGE[level] ?? 'bg-secondary';
+  }
+
+  isGapCorrect(gap: StoryGap): boolean {
+    return this.answers[gap.position] === this.correctAnswer(gap);
+  }
+
+  correctAnswer(gap: StoryGap): string {
+    return gap.options.find((o) => o.correct)?.text ?? '';
+  }
+
+  gapSelectClass(gap: StoryGap): Record<string, boolean> {
+    return {
+      'border-success': this.submitted && this.isGapCorrect(gap),
+      'text-success': this.submitted && this.isGapCorrect(gap),
+      'border-danger': this.submitted && !this.isGapCorrect(gap),
+      'text-danger': this.submitted && !this.isGapCorrect(gap),
+    };
+  }
+
+  gapHintKey(gap: StoryGap): string {
+    return `learnDeutschStories.category.${gap.category}`;
+  }
+
+  gapCaseKey(gap: StoryGap): string | null {
+    return gap.grammaticalCase
+      ? `learnDeutschStories.case.${gap.grammaticalCase}`
+      : null;
+  }
+
+  private initStory(story: Story): void {
+    this.story = story;
+    this.segments = this.parseBody(story);
+    this.answers = {};
+    this.submitted = false;
+    this.correctCount = 0;
+    this.state = 'assess';
+  }
+
+  private parseBody(story: Story): Segment[] {
+    const segments: Segment[] = [];
+    const re = /\{\{(\d+)\}\}/g;
+    let last = 0;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(story.body)) !== null) {
+      if (match.index > last) {
+        segments.push({ kind: 'text', text: story.body.slice(last, match.index) });
+      }
+      const gap = story.gaps.find((g) => g.position === Number(match![1]));
+      if (gap) {
+        segments.push({ kind: 'gap', gap });
+      } else {
+        segments.push({ kind: 'text', text: match[0] });
+      }
+      last = re.lastIndex;
+    }
+    if (last < story.body.length) {
+      segments.push({ kind: 'text', text: story.body.slice(last) });
+    }
+    return segments;
+  }
+}

--- a/src/app/learn-deutsch-stories/learn-deutsch-stories.model.ts
+++ b/src/app/learn-deutsch-stories/learn-deutsch-stories.model.ts
@@ -1,0 +1,38 @@
+export type DeutschLevel = 'A1' | 'A2' | 'B1' | 'B2' | 'C1' | 'C2';
+
+export type GapCategory =
+  | 'ARTICLE'
+  | 'ADJECTIVE_ENDING'
+  | 'PRONOUN'
+  | 'PREPOSITION'
+  | 'VERB_FORM';
+
+export type GrammaticalCase = 'NOMINATIV' | 'AKKUSATIV' | 'DATIV' | 'GENITIV';
+
+export interface StorySummary {
+  uuid: string;
+  title: string;
+  level: DeutschLevel;
+  topic: string;
+}
+
+export interface StoryGapOption {
+  text: string;
+  correct: boolean;
+}
+
+export interface StoryGap {
+  position: number;
+  category: GapCategory;
+  grammaticalCase: GrammaticalCase | null;
+  options: StoryGapOption[];
+}
+
+export interface Story {
+  uuid: string;
+  title: string;
+  level: DeutschLevel;
+  topic: string;
+  body: string;
+  gaps: StoryGap[];
+}

--- a/src/app/learn-deutsch-stories/learn-deutsch-stories.service.ts
+++ b/src/app/learn-deutsch-stories/learn-deutsch-stories.service.ts
@@ -1,0 +1,19 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Story, StorySummary } from './learn-deutsch-stories.model';
+import { environment as env } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class LearnDeutschStoriesService {
+  private readonly baseUrl = `${env.apiBaseUrl}/public/deutsch/stories`;
+  private readonly http = inject(HttpClient);
+
+  getStories(): Observable<StorySummary[]> {
+    return this.http.get<StorySummary[]>(this.baseUrl);
+  }
+
+  getStory(uuid: string): Observable<Story> {
+    return this.http.get<Story>(`${this.baseUrl}/${uuid}`);
+  }
+}

--- a/src/app/learn-deutsch/learn-deutsch.service.ts
+++ b/src/app/learn-deutsch/learn-deutsch.service.ts
@@ -11,6 +11,6 @@ export class LearnDeutschService {
 
   getNouns(limit = 100, lang = 'en'): Observable<DeutschNoun[]> {
     const params = new HttpParams().set('limit', limit).set('lang', lang);
-    return this.http.get<DeutschNoun[]>(`${this.baseUrl}/nouns/de`, { params });
+    return this.http.get<DeutschNoun[]>(`${this.baseUrl}/deutsch/nouns`, { params });
   }
 }


### PR DESCRIPTION
- Add public story assessment feature (learn-deutsch-stories): story list and fill-the-gaps exercise graded client-side via the gap option flag
- Add a learn-deutsch hub page; landing "Learn German" button now lands there with Articles (moved to /learn-deutsch/practice) and Stories
- Add admin UI to generate DE stories (POST /admin/deutsch/stories/generate)
- Adapt noun endpoint to /public/deutsch/nouns
- Add i18n keys for hub and stories in en/it/de/es